### PR TITLE
Snakefile: update to newer pypsa-eur with '_ec' in filename

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -172,7 +172,7 @@ rule build_industrial_demand:
 
 rule prepare_sector_network:
     input:
-        network=pypsaeur('networks/{network}_s{simpl}_{clusters}_lv{lv}_{opts}.nc'),
+        network=pypsaeur('networks/{network}_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
         energy_totals_name='data/energy_totals.csv',
         co2_totals_name='data/co2_totals.csv',
         transport_name='data/transport_data.csv',


### PR DESCRIPTION
If you seek to at some point use a newer version of PyPSA-Eur beyond https://github.com/PyPSA/pypsa-eur/commit/81d9d2ab4d5dccec14db1b02283bd0b04d1acbed, this change is necessary. 