### PR TITLE
Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pypsa-eur"]
+	path = pypsa-eur
+	url = https://github.com/pypsa/pypsa-eur

--- a/README.md
+++ b/README.md
@@ -86,17 +86,15 @@ Liquid hydrocarbons: copper-plated since transport costs are low.
 
 # Installation
 
-First install [PyPSA-Eur](https://github.com/PyPSA/pypsa-eur) and all
-its dependencies. Clone the repository:
+Clone the PyPSA-Eur-Sec repository with:
 ```shell
-projects % git clone git@github.com:PyPSA/pypsa-eur.git
+projects % git clone --recurse-submodules git@github.com:PyPSA/pypsa-eur-sec.git
 ```
-then download and unpack all the data files.
 
-Create a parallel directory for PyPSA-Eur-Sec with:
-```shell
-projects % git clone git@github.com:nworbmot/pypsa-eur-sec.git
-```
+This also clones [PyPSA-Eur](https://github.com/PyPSA/pypsa-eur)
+as a submodule.
+[Install all its dependencies](https://pypsa-eur.readthedocs.io/en/latest/installation.html).
+
 
 ## Package requirements
 

--- a/Snakefile
+++ b/Snakefile
@@ -12,9 +12,9 @@ wildcard_constraints:
 
 
 subworkflow pypsaeur:
-    workdir: "../pypsa-eur"
-    snakefile: "../pypsa-eur/Snakefile"
-    configfile: "../pypsa-eur/config.yaml"
+    workdir: "pypsa-eur"
+    snakefile: "pypsa-eur/Snakefile"
+    configfile: "pypsa-eur/config.yaml"
 
 rule all:
      input: config['summary_dir'] + '/' + config['run'] + '/graphs/costs.pdf'

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -3,7 +3,7 @@ from six import iteritems
 
 import sys
 
-sys.path.append("../pypsa-eur/scripts")
+sys.path.append("pypsa-eur/scripts")
 
 import pandas as pd
 


### PR DESCRIPTION
closes #38

Rather than maintaining a PyPSA-Eur folder parallel to PyPSA-Eur-Sec, this PR proposes to introduce PyPSA-Eur as a `git submodule`.

The main advantages are:
- simplify installation (clone just one repository)
- maintain working PyPSA-Eur version (possible to checkout and commit a compatible PyPSA-Eur commit/version directly in the PyPSA-Eur-Sec repository)

Disadvantages (?):
- Is there a benefit from keeping PyPSA-Eur as a parallel folder rather than a subfolder which I overlooked?

Installation instructions updated accordingly.

