### PR TITLE
Calculate industrial production in Mt/a before calculating corresponding energy demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ gurobi.log
 config.yaml
 
 doc/_build
+
+*.xls

--- a/Snakefile
+++ b/Snakefile
@@ -146,8 +146,19 @@ rule build_biomass_potentials:
     resources: mem_mb=1000
     script: 'scripts/build_biomass_potentials.py'
 
+rule build_ammonia_production:
+    input:
+        usgs="data/myb1-2017-nitro.xls"
+    output:
+        ammonia_production="resources/ammonia_production.csv"
+    threads: 1
+    resources: mem_mb=1000
+    script: 'scripts/build_ammonia_production.py'
+
 
 rule build_industry_sector_ratios:
+    input:
+        ammonia_production="resources/ammonia_production.csv"
     output:
         industry_sector_ratios="resources/industry_sector_ratios.csv"
     threads: 1
@@ -156,6 +167,8 @@ rule build_industry_sector_ratios:
 
 
 rule build_industrial_production_per_country:
+    input:
+        ammonia_production="resources/ammonia_production.csv"
     output:
         industrial_production_per_country="resources/industrial_production_per_country.csv"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -187,7 +187,8 @@ rule build_industrial_production_per_country_tomorrow:
 
 rule build_industrial_energy_demand_per_country_today:
     input:
-        ammonia_production="resources/ammonia_production.csv"
+        ammonia_production="resources/ammonia_production.csv",
+        industrial_production_per_country="resources/industrial_production_per_country.csv"
     output:
         industrial_energy_demand_per_country_today="resources/industrial_energy_demand_per_country_today.csv"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -186,6 +186,8 @@ rule build_industrial_production_per_country_tomorrow:
     script: 'scripts/build_industrial_production_per_country_tomorrow.py'
 
 rule build_industrial_energy_demand_per_country_today:
+    input:
+        ammonia_production="resources/ammonia_production.csv"
     output:
         industrial_energy_demand_per_country_today="resources/industrial_energy_demand_per_country_today.csv"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -159,7 +159,8 @@ rule build_industrial_demand_per_country:
     input:
         industry_sector_ratios="resources/industry_sector_ratios.csv"
     output:
-        industrial_demand_per_country="resources/industrial_demand_per_country.csv"
+        industrial_demand_per_country="resources/industrial_demand_per_country.csv",
+        industrial_energy_demand_per_country="resources/industrial_energy_demand_per_country.csv"
     threads: 1
     resources: mem_mb=1000
     script: 'scripts/build_industrial_demand_per_country.py'
@@ -168,7 +169,7 @@ rule build_industrial_demand_per_country:
 rule build_industrial_demand:
     input:
         clustered_pop_layout="resources/pop_layout_{network}_s{simpl}_{clusters}.csv",
-        industrial_demand_per_country="resources/industrial_demand_per_country.csv"
+        industrial_demand_per_country="resources/industrial_energy_demand_per_country.csv"
     output:
         industrial_demand="resources/industrial_demand_{network}_s{simpl}_{clusters}.csv"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -185,6 +185,13 @@ rule build_industrial_production_per_country_tomorrow:
     resources: mem_mb=1000
     script: 'scripts/build_industrial_production_per_country_tomorrow.py'
 
+rule build_industrial_energy_demand_per_country_today:
+    output:
+        industrial_energy_demand_per_country_today="resources/industrial_energy_demand_per_country_today.csv"
+    threads: 1
+    resources: mem_mb=1000
+    script: 'scripts/build_industrial_energy_demand_per_country_today.py'
+
 
 rule build_industrial_energy_demand_per_country:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -130,9 +130,9 @@ rule build_energy_totals:
     input:
         nuts3_shapes=pypsaeur('resources/nuts3_shapes.geojson')
     output:
-        energy_name='data/energy_totals.csv',
-	co2_name='data/co2_totals.csv',
-	transport_name='data/transport_data.csv'
+        energy_name='resources/energy_totals.csv',
+	co2_name='resources/co2_totals.csv',
+	transport_name='resources/transport_data.csv'
     threads: 1
     resources: mem_mb=10000
     script: 'scripts/build_energy_totals.py'
@@ -141,7 +141,7 @@ rule build_biomass_potentials:
     input:
         jrc_potentials="data/biomass/JRC Biomass Potentials.xlsx"
     output:
-        biomass_potentials='data/biomass_potentials.csv'
+        biomass_potentials='resources/biomass_potentials.csv'
     threads: 1
     resources: mem_mb=1000
     script: 'scripts/build_biomass_potentials.py'
@@ -221,10 +221,10 @@ rule build_industrial_demand:
 rule prepare_sector_network:
     input:
         network=pypsaeur('networks/{network}_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
-        energy_totals_name='data/energy_totals.csv',
-        co2_totals_name='data/co2_totals.csv',
-        transport_name='data/transport_data.csv',
-        biomass_potentials='data/biomass_potentials.csv',
+        energy_totals_name='resources/energy_totals.csv',
+        co2_totals_name='resources/co2_totals.csv',
+        transport_name='resources/transport_data.csv',
+        biomass_potentials='resources/biomass_potentials.csv',
         timezone_mappings='data/timezone_mappings.csv',
         heat_profile="data/heat_load_profile_BDEW.csv",
         costs=config['costs_dir'] + "costs_{planning_horizons}.csv",

--- a/Snakefile
+++ b/Snakefile
@@ -155,15 +155,23 @@ rule build_industry_sector_ratios:
     script: 'scripts/build_industry_sector_ratios.py'
 
 
-rule build_industrial_demand_per_country:
-    input:
-        industry_sector_ratios="resources/industry_sector_ratios.csv"
+rule build_industrial_production_per_country:
     output:
-        industrial_demand_per_country="resources/industrial_demand_per_country.csv",
+        industrial_production_per_country="resources/industrial_production_per_country.csv"
+    threads: 1
+    resources: mem_mb=1000
+    script: 'scripts/build_industrial_production_per_country.py'
+
+
+rule build_industrial_energy_demand_per_country:
+    input:
+        industry_sector_ratios="resources/industry_sector_ratios.csv",
+        industrial_production_per_country="resources/industrial_production_per_country.csv"
+    output:
         industrial_energy_demand_per_country="resources/industrial_energy_demand_per_country.csv"
     threads: 1
     resources: mem_mb=1000
-    script: 'scripts/build_industrial_demand_per_country.py'
+    script: 'scripts/build_industrial_energy_demand_per_country.py'
 
 
 rule build_industrial_demand:

--- a/Snakefile
+++ b/Snakefile
@@ -163,10 +163,20 @@ rule build_industrial_production_per_country:
     script: 'scripts/build_industrial_production_per_country.py'
 
 
+rule build_industrial_production_per_country_tomorrow:
+    input:
+        industrial_production_per_country="resources/industrial_production_per_country.csv"
+    output:
+        industrial_production_per_country_tomorrow="resources/industrial_production_per_country_tomorrow.csv"
+    threads: 1
+    resources: mem_mb=1000
+    script: 'scripts/build_industrial_production_per_country_tomorrow.py'
+
+
 rule build_industrial_energy_demand_per_country:
     input:
         industry_sector_ratios="resources/industry_sector_ratios.csv",
-        industrial_production_per_country="resources/industrial_production_per_country.csv"
+        industrial_production_per_country="resources/industrial_production_per_country_tomorrow.csv"
     output:
         industrial_energy_demand_per_country="resources/industrial_energy_demand_per_country.csv"
     threads: 1

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -161,7 +161,10 @@ industry:
   'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
   'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
   'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
-  'H2_for_NH3' : 85000 # H2 in GWh/a for 17 MtNH3/a transformed from SMR to electrolyzed-H2, following Lechtenböhmer(2016)
+  'MWh_CH4_per_tNH3_SMR' : 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  'MWh_elec_per_tNH3_SMR' : 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  'MWh_H2_per_tNH3_electrolysis' : 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  'MWh_elec_per_tNH3_electrolysis' : 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
   'NH3_process_emissions' : 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
   'petrochemical_process_emissions' : 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -158,9 +158,9 @@ solving:
   mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
 
 industry:
-  'DRI_ratio' : 0.5 #ratio of today's blast-furnace steel (60% primary route, 40% secondary) to future assumption (30% primary, 70% secondary), transformed into DRI + electric arc
-  'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
-  'Al_to_scrap' : 0.5 # ratio of primary-route Aluminum transformed into scrap (today 40% to future 20% primary route)
+  'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
+  'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
   'H2_for_NH3' : 85000 # H2 in GWh/a for 17 MtNH3/a transformed from SMR to electrolyzed-H2, following Lechtenböhmer(2016)
   'NH3_process_emissions' : 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
   'petrochemical_process_emissions' : 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -160,6 +160,7 @@ solving:
 industry:
   'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
   'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  'elec_DRI' : 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
   'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
   'MWh_CH4_per_tNH3_SMR' : 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
   'MWh_elec_per_tNH3_SMR' : 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3

--- a/config.myopic.yaml
+++ b/config.myopic.yaml
@@ -161,7 +161,10 @@ industry:
   'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
   'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
   'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
-  'H2_for_NH3' : 85000 # H2 in GWh/a for 17 MtNH3/a transformed from SMR to electrolyzed-H2, following Lechtenböhmer(2016)
+  'MWh_CH4_per_tNH3_SMR' : 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
+  'MWh_elec_per_tNH3_SMR' : 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3
+  'MWh_H2_per_tNH3_electrolysis' : 6.5 # from https://doi.org/10.1016/j.joule.2018.04.017, around 0.197 tH2/tHN3 (>3/17 since some H2 lost and used for energy)
+  'MWh_elec_per_tNH3_electrolysis' : 1.17 # from https://doi.org/10.1016/j.joule.2018.04.017 Table 13 (air separation and HB)
   'NH3_process_emissions' : 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
   'petrochemical_process_emissions' : 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28
 

--- a/config.myopic.yaml
+++ b/config.myopic.yaml
@@ -158,9 +158,9 @@ solving:
   mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
 
 industry:
-  'DRI_ratio' : 0.5 #ratio of today's blast-furnace steel (60% primary route, 40% secondary) to future assumption (30% primary, 70% secondary), transformed into DRI + electric arc
-  'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
-  'Al_to_scrap' : 0.5 # ratio of primary-route Aluminum transformed into scrap (today 40% to future 20% primary route)
+  'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
+  'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
   'H2_for_NH3' : 85000 # H2 in GWh/a for 17 MtNH3/a transformed from SMR to electrolyzed-H2, following Lechtenböhmer(2016)
   'NH3_process_emissions' : 24.5 # in MtCO2/a from SMR for H2 production for NH3 from UNFCCC for 2015 for EU28
   'petrochemical_process_emissions' : 25.5 # in MtCO2/a for petrochemical and other from UNFCCC for 2015 for EU28

--- a/config.myopic.yaml
+++ b/config.myopic.yaml
@@ -160,6 +160,7 @@ solving:
 industry:
   'St_primary_fraction' : 0.3 # fraction of steel produced via primary route (DRI + EAF) versus secondary route (EAF); today fraction is 0.6
   'H2_DRI' : 1.7   #H2 consumption in Direct Reduced Iron (DRI),  MWh_H2,LHV/ton_Steel from Vogl et al (2018) doi:10.1016/j.jclepro.2018.08.279
+  'elec_DRI' : 0.322   #electricity consumption in Direct Reduced Iron (DRI) shaft, MWh/tSt HYBRIT brochure https://ssabwebsitecdn.azureedge.net/-/media/hybrit/files/hybrit_brochure.pdf
   'Al_primary_fraction' : 0.2 # fraction of aluminium produced via the primary route versus scrap; today fraction is 0.4
   'MWh_CH4_per_tNH3_SMR' : 10.8 # 2012's demand from https://ec.europa.eu/docsroom/documents/4165/attachments/1/translations/en/renditions/pdf
   'MWh_elec_per_tNH3_SMR' : 0.7 # same source, assuming 94-6% split methane-elec of total energy demand 11.5 MWh/tNH3

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -65,8 +65,8 @@ To download and extract it on the command line:
 
 .. code:: bash
 
-    projects/pypsa-eur-sec/data % wget "https://nworbmot.org/pypsa-eur-sec-data-bundle-190719.tar.gz"
-    projects/pypsa-eur-sec/data % tar xvzf pypsa-eur-sec-data-bundle-190719.tar.gz
+    projects/pypsa-eur-sec/data % wget "https://nworbmot.org/pypsa-eur-sec-data-bundle-200921.tar.gz"
+    projects/pypsa-eur-sec/data % tar xvzf pypsa-eur-sec-data-bundle-200921.tar.gz
 
 Set up the default configuration
 ================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -74,3 +74,9 @@ Release Process
 * Make a `GitHub release <https://github.com/PyPSA/pypsa-eur-sec/releases>`_, which automatically triggers archiving by `zenodo <https://doi.org/10.5281/zenodo.3938042>`_.
 
 * Send announcement on the `PyPSA mailing list <https://groups.google.com/forum/#!forum/pypsa>`_.
+
+To make a new release of the data bundle, do:
+
+.. code:: bash
+
+    data % tar pczf pypsa-eur-sec-data-bundle-date.tar.gz eea switzerland-sfoe biomass eurostat-energy_balances-* jrc-idees-2015 emobility urban_percent.csv timezone_mappings.csv heat_load_profile_DK_AdamJensen.csv WindWaveWEC_GLTB.xlsx myb1-2017-nitro.xls

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -1,0 +1,45 @@
+
+
+import pandas as pd
+
+ammonia = pd.read_excel(snakemake.input.usgs,
+                        sheet_name="T12",
+                        skiprows=5,
+                        header=0,
+                        index_col=0,
+                        skipfooter=19)
+
+rename = {"Austriae" : "AT",
+          "Bulgaria" : "BG",
+          "Belgiume" : "BE",
+          "Croatia" : "HR",
+          "Czechia" : "CZ",
+          "Estonia" : "EE",
+          "Finland" : "FI",
+          "France" : "FR",
+          "Germany" : "DE",
+          "Greece" : "GR",
+          "Hungarye" : "HU",
+          "Italye" : "IT",
+          "Lithuania" : "LT",
+          "Netherlands" : "NL",
+          "Norwaye" : "NO",
+          "Poland" : "PL",
+          "Romania" : "RO",
+          "Serbia" : "RS",
+          "Slovakia" : "SK",
+          "Spain" : "ES",
+          "Switzerland" : "CH",
+          "United Kingdom" : "GB",
+}
+
+ammonia = ammonia.rename(rename)
+
+ammonia = ammonia.loc[rename.values(),[str(i) for i in range(2013,2018)]].astype(float)
+
+#convert from ktonN to ktonNH3
+ammonia = ammonia*17/14
+
+ammonia.index.name = "ktonNH3/a"
+
+ammonia.to_csv(snakemake.output.ammonia_production)

--- a/scripts/build_industrial_demand.py
+++ b/scripts/build_industrial_demand.py
@@ -7,7 +7,7 @@ def build_industrial_demand():
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout,index_col=0)
     pop_layout["ct"] = pop_layout.index.str[:2]
     ct_total = pop_layout.total.groupby(pop_layout["ct"]).sum()
-    pop_layout["ct_total"] = pop_layout["ct"].map(ct_total.get)
+    pop_layout["ct_total"] = pop_layout["ct"].map(ct_total)
     pop_layout["fraction"] = pop_layout["total"]/pop_layout["ct_total"]
 
     industrial_demand_per_country = pd.read_csv(snakemake.input.industrial_demand_per_country,index_col=0)

--- a/scripts/build_industrial_energy_demand_per_country.py
+++ b/scripts/build_industrial_energy_demand_per_country.py
@@ -10,7 +10,8 @@ eb_base_dir = "data/eurostat-energy_balances-may_2018_edition"
 jrc_base_dir = "data/jrc-idees-2015"
 
 # import EU ratios df as csv
-industry_sector_ratios=pd.read_csv(snakemake.input.industry_sector_ratios, sep=';', index_col=0)
+industry_sector_ratios=pd.read_csv(snakemake.input.industry_sector_ratios,
+                                   index_col=0)
 
 #material demand per country and industry (kton/a)
 countries_production = pd.read_csv(snakemake.input.industrial_production_per_country, index_col=0)

--- a/scripts/build_industrial_energy_demand_per_country.py
+++ b/scripts/build_industrial_energy_demand_per_country.py
@@ -68,8 +68,6 @@ for country in countries_df.index:
 
         s_out = excel_out.iloc[27:48,-1]
         countries_df.loc[country, 'current electricity'] = s_out['Electricity']*ktoe_to_twh
-        print(countries_df.loc[country, 'current electricity'])
-
 
 
 rename_sectors = {'elec':'electricity',

--- a/scripts/build_industrial_energy_demand_per_country.py
+++ b/scripts/build_industrial_energy_demand_per_country.py
@@ -1,0 +1,84 @@
+
+import pandas as pd
+import numpy as np
+
+
+tj_to_ktoe = 0.0238845
+ktoe_to_twh = 0.01163
+
+eb_base_dir = "data/eurostat-energy_balances-may_2018_edition"
+jrc_base_dir = "data/jrc-idees-2015"
+
+# import EU ratios df as csv
+industry_sector_ratios=pd.read_csv(snakemake.input.industry_sector_ratios, sep=';', index_col=0)
+
+#material demand per country and industry (kton/a)
+countries_production = pd.read_csv(snakemake.input.industrial_production_per_country, index_col=0)
+
+#Annual energy consumption in Switzerland by sector in 2015 (in TJ)
+#From: Energieverbrauch in der Industrie und im Dienstleistungssektor, Der Bundesrat
+#http://www.bfe.admin.ch/themen/00526/00541/00543/index.html?lang=de&dossier_id=00775
+
+dic_Switzerland ={'Iron and steel': 7889.,
+          'Chemicals Industry': 26871.,
+          'Non-metallic mineral products': 15513.+3820.,
+          'Pulp, paper and printing': 12004.,
+          'Food, beverages and tobacco': 17728.,
+          'Non Ferrous Metals': 3037.,
+          'Transport Equipment': 14993.,
+          'Machinery Equipment': 4724.,
+          'Textiles and leather': 1742.,
+          'Wood and wood products': 0.,
+          'Other Industrial Sectors': 10825.,
+          'current electricity': 53760.}
+
+
+eb_names={'NO':'Norway', 'AL':'Albania', 'BA':'Bosnia and Herzegovina',
+          'MK':'FYR of Macedonia', 'GE':'Georgia', 'IS':'Iceland',
+          'KO':'Kosovo', 'MD':'Moldova', 'ME':'Montenegro', 'RS':'Serbia',
+          'UA':'Ukraine', 'TR':'Turkey', }
+
+jrc_names = {"GR" : "EL",
+             "GB" : "UK"}
+
+#final energy consumption per country and industry (TWh/a)
+countries_df = countries_production.dot(industry_sector_ratios.T)
+countries_df*= 0.001 #GWh -> TWh (ktCO2 -> MtCO2)
+
+
+
+non_EU = ['NO', 'CH', 'ME', 'MK', 'RS', 'BA', 'AL']
+
+
+# save current electricity consumption
+for country in countries_df.index:
+    if country in non_EU:
+        if country == 'CH':
+            countries_df.loc[country, 'current electricity']=dic_Switzerland['current electricity']*tj_to_ktoe*ktoe_to_twh
+        else:
+            excel_balances = pd.read_excel('{}/{}.XLSX'.format(eb_base_dir,eb_names[country]),
+                                      sheet_name='2016', index_col=1,header=0, skiprows=1 ,squeeze=True)
+
+            countries_df.loc[country, 'current electricity'] = excel_balances.loc['Industry', 'Electricity']*ktoe_to_twh
+
+    else:
+
+        excel_out = pd.read_excel('{}/JRC-IDEES-2015_Industry_{}.xlsx'.format(jrc_base_dir,jrc_names.get(country,country)),
+                                  sheet_name='Ind_Summary',index_col=0,header=0,squeeze=True) # the summary sheet
+
+        s_out = excel_out.iloc[27:48,-1]
+        countries_df.loc[country, 'current electricity'] = s_out['Electricity']*ktoe_to_twh
+        print(countries_df.loc[country, 'current electricity'])
+
+
+
+rename_sectors = {'elec':'electricity',
+                  'biomass':'solid biomass',
+                  'heat':'low-temperature heat'}
+
+countries_df.rename(columns=rename_sectors,inplace=True)
+
+countries_df.index.name = "TWh/a (MtCO2/a)"
+
+countries_df.to_csv(snakemake.output.industrial_energy_demand_per_country,
+                    float_format='%.2f')

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -1,0 +1,107 @@
+
+import pandas as pd
+
+# sub-sectors as used in PyPSA-Eur-Sec and listed in JRC-IDEES industry sheets
+sub_sectors = {'Iron and steel' : ['Integrated steelworks','Electric arc'],
+               'Non-ferrous metals' : ['Alumina production','Aluminium - primary production','Aluminium - secondary production','Other non-ferrous metals'],
+               'Chemicals' : ['Basic chemicals', 'Other chemicals', 'Pharmaceutical products etc.', 'Basic chemicals feedstock'],
+               'Non-metalic mineral' : ['Cement','Ceramics & other NMM','Glass production'],
+               'Printing' : ['Pulp production','Paper production','Printing and media reproduction'],
+               'Food' : ['Food, beverages and tobacco'],
+               'Transport equipment' : ['Transport Equipment'],
+               'Machinery equipment' : ['Machinery Equipment'],
+               'Textiles and leather' : ['Textiles and leather'],
+               'Wood and wood products' : ['Wood and wood products'],
+               'Other Industrial Sectors' : ['Other Industrial Sectors'],
+}
+
+
+# name in JRC-IDEES Energy Balances
+eb_sheet_name = {'Integrated steelworks' : 'cisb',
+                 'Electric arc' : 'cise',
+                 'Alumina production' : 'cnfa',
+                 'Aluminium - primary production' : 'cnfp',
+                 'Aluminium - secondary production' : 'cnfs',
+                 'Other non-ferrous metals' : 'cnfo',
+                 'Basic chemicals' : 'cbch',
+                 'Other chemicals' : 'coch',
+                 'Pharmaceutical products etc.' : 'cpha',
+                 'Basic chemicals feedstock' : 'cpch',
+                 'Cement' : 'ccem',
+                 'Ceramics & other NMM' : 'ccer',
+                 'Glass production' : 'cgla',
+                 'Pulp production' : 'cpul',
+                 'Paper production' : 'cpap',
+                 'Printing and media reproduction' : 'cprp',
+                 'Food, beverages and tobacco' : 'cfbt',
+                 'Transport Equipment' : 'ctre',
+                 'Machinery Equipment' : 'cmae',
+                 'Textiles and leather' : 'ctel',
+                 'Wood and wood products' : 'cwwp',
+                 'Mining and quarrying' : 'cmiq',
+                 'Construction' : 'ccon',
+                 'Non-specified': 'cnsi',
+}
+
+
+
+fuels = {'all' : ['All Products'],
+         'solid' : ['Solid Fuels'],
+         'liquid' : ['Total petroleum products (without biofuels)'],
+         'gas' : ['Gases'],
+         'heat' : ['Nuclear heat','Derived heat'],
+         'biomass' : ['Biomass and Renewable wastes'],
+         'waste' : ['Wastes (non-renewable)'],
+         'electricity' : ['Electricity'],
+}
+
+ktoe_to_twh = 0.011630
+
+eu28 = ['FR', 'DE', 'GB', 'IT', 'ES', 'PL', 'SE', 'NL', 'BE', 'FI',
+        'DK', 'PT', 'RO', 'AT', 'BG', 'EE', 'GR', 'LV', 'CZ',
+        'HU', 'IE', 'SK', 'LT', 'HR', 'LU', 'SI', 'CY', 'MT']
+
+jrc_names = {"GR" : "EL",
+             "GB" : "UK"}
+
+year = 2015
+summaries = {}
+
+#for some reason the Energy Balances list Other Industrial Sectors separately
+ois_subs = ['Mining and quarrying','Construction','Non-specified']
+
+
+
+for ct in eu28:
+    print(ct)
+    filename = 'data/jrc-idees-2015/JRC-IDEES-2015_EnergyBalance_{}.xlsx'.format(jrc_names.get(ct,ct))
+
+    summary = pd.DataFrame(index=list(fuels.keys()) + ['other'])
+
+    for sector in sub_sectors:
+        if sector == 'Other Industrial Sectors':
+            subs = ois_subs
+        else:
+            subs = sub_sectors[sector]
+
+        for sub in subs:
+            df = pd.read_excel(filename,
+                               sheet_name=eb_sheet_name[sub],
+                               index_col=0)
+
+            s = df[year].astype(float)
+
+            for fuel in fuels:
+                summary.at[fuel,sub] = s[fuels[fuel]].sum()
+                summary.at['other',sub] = summary.at['all',sub] - summary.loc[summary.index^['all','other'],sub].sum()
+
+    summary['Other Industrial Sectors'] = summary[ois_subs].sum(axis=1)
+    summary.drop(columns=ois_subs,inplace=True)
+
+    summaries[ct] = summary*ktoe_to_twh
+
+final_summary = pd.concat(summaries,axis=1)
+
+final_summary.index.name = 'TWh/a'
+
+final_summary.to_csv(snakemake.output.industrial_energy_demand_per_country_today)

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -121,6 +121,20 @@ for ct in eu28:
 
 final_summary = pd.concat(summaries,axis=1)
 
+# add in the non-EU28 based on their output (which is derived from their energy too)
+# output in MtMaterial/a
+output = pd.read_csv(snakemake.input.industrial_production_per_country,
+                     index_col=0)/1e3
+
+eu28_averages = final_summary.groupby(level=1,axis=1).sum().divide(output.loc[eu28].sum(),axis=1)
+
+non_eu28 = output.index^eu28
+
+for ct in non_eu28:
+    print(ct)
+    final_summary = pd.concat((final_summary,pd.concat({ct : eu28_averages.multiply(output.loc[ct],axis=1)},axis=1)),axis=1)
+
+
 final_summary.index.name = 'TWh/a'
 
 final_summary.to_csv(snakemake.output.industrial_energy_demand_per_country_today)

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -6,16 +6,21 @@ industrial_production = pd.read_csv(snakemake.input.industrial_production_per_co
 
 total_steel = industrial_production[["Integrated steelworks","Electric arc"]].sum(axis=1)
 
+fraction_primary_stays_primary = snakemake.config["industry"]["St_primary_fraction"]*total_steel.sum()/industrial_production["Integrated steelworks"].sum()
+
 industrial_production.insert(2, "DRI + Electric arc",
-                             snakemake.config["industry"]["St_primary_fraction"]*total_steel)
-industrial_production["Electric arc"] = (1 - snakemake.config["industry"]["St_primary_fraction"])*total_steel
+                             fraction_primary_stays_primary*industrial_production["Integrated steelworks"])
+
+industrial_production["Electric arc"] = total_steel - industrial_production["DRI + Electric arc"]
 industrial_production["Integrated steelworks"] = 0.
 
 
 total_aluminium = industrial_production[["Aluminium - primary production","Aluminium - secondary production"]].sum(axis=1)
 
-industrial_production["Aluminium - primary production"] = snakemake.config["industry"]["Al_primary_fraction"]*total_aluminium
-industrial_production["Aluminium - secondary production"] = (1 - snakemake.config["industry"]["Al_primary_fraction"])*total_aluminium
+fraction_primary_stays_primary = snakemake.config["industry"]["Al_primary_fraction"]*total_aluminium.sum()/industrial_production["Aluminium - primary production"].sum()
+
+industrial_production["Aluminium - primary production"] = fraction_primary_stays_primary*industrial_production["Aluminium - primary production"]
+industrial_production["Aluminium - secondary production"] = total_aluminium - industrial_production["Aluminium - primary production"]
 
 
 industrial_production.to_csv(snakemake.output.industrial_production_per_country_tomorrow,

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -1,0 +1,22 @@
+
+import pandas as pd
+
+industrial_production = pd.read_csv(snakemake.input.industrial_production_per_country,
+                                    index_col=0)
+
+total_steel = industrial_production[["Integrated steelworks","Electric arc"]].sum(axis=1)
+
+industrial_production.insert(2, "DRI + Electric arc",
+                             snakemake.config["industry"]["St_primary_fraction"]*total_steel)
+industrial_production["Electric arc"] = (1 - snakemake.config["industry"]["St_primary_fraction"])*total_steel
+industrial_production["Integrated steelworks"] = 0.
+
+
+total_aluminium = industrial_production[["Aluminium - primary production","Aluminium - secondary production"]].sum(axis=1)
+
+industrial_production["Aluminium - primary production"] = snakemake.config["industry"]["Al_primary_fraction"]*total_aluminium
+industrial_production["Aluminium - secondary production"] = (1 - snakemake.config["industry"]["Al_primary_fraction"])*total_aluminium
+
+
+industrial_production.to_csv(snakemake.output.industrial_production_per_country_tomorrow,
+                             float_format='%.2f')

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -156,6 +156,8 @@ df['DRI + Electric arc'] = df['Electric arc']
 
 # adding the Hydrogen necessary for the Direct Reduction of Iron. consumption 1.7 MWh H2 /ton steel
 df.loc['hydrogen', 'DRI + Electric arc'] = snakemake.config["industry"]["H2_DRI"]
+# add electricity consumption in DRI shaft (0.322 MWh/tSl)
+df.loc['elec', 'DRI + Electric arc'] += snakemake.config["industry"]["elec_DRI"]
 
 
 ### Integrated steelworks (could be used in combination with CCS)

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -152,19 +152,18 @@ df.loc[['elec','heat','methane'],sector] = df.loc[['elec','heat','methane'],sect
 
 
 
-## Integrated steelworks is converted to Electric arc
-#
-#> Electric arc uses scrap metal and Direct Reduced Iron
-#
-#> We assume that when substituting Integrated Steelworks by Electric arc furnaces.
-#> 50% of Integrated steelworks is substituted by scrap metal + electric furnaces
-#> 50% of Integrated steelworks is substituted by Direct Reduce Iron (with Hydrogen) + electric furnaces
+## Integrated steelworks is not used in future
+## TODO Include integrated steelworks + CCS
 
-df['Integrated steelworks']=df['Electric arc']
+df['Integrated steelworks']= 0.
+
+
+## For primary route: DRI with H2 + EAF
+
+df['DRI + Electric arc'] = df['Electric arc']
 
 # adding the Hydrogen necessary for the Direct Reduction of Iron. consumption 1.7 MWh H2 /ton steel
-#(0.5 because only half of the steel requires DRI, the rest is scrap  metal)
-df.loc['hydrogen', 'Integrated steelworks'] =snakemake.config["industry"]["H2_DRI"] * snakemake.config["industry"]["DRI_ratio"]
+df.loc['hydrogen', 'DRI + Electric arc'] = snakemake.config["industry"]["H2_DRI"]
 
 
 ## Chemicals Industry
@@ -1052,9 +1051,6 @@ sources=['elec','biomass', 'methane', 'hydrogen', 'heat','naphtha']
 df.loc[sources,sector] = df.loc[sources,sector]*conv_factor/s_out['Aluminium - secondary production'] # unit MWh/t material
 # 1 ktoe = 11630 MWh
 
-# primary route is divided into 50% remains as today and 50% is transformed into secondary route
-df.loc[sources,'Aluminium - primary production'] = (1-snakemake.config["industry"]["Al_to_scrap"])*df.loc[sources,'Aluminium - primary production'] + snakemake.config["industry"]["Al_to_scrap"]*df.loc[sources,'Aluminium - secondary production']
-df.loc['process emission','Aluminium - primary production'] = (1-snakemake.config["industry"]["Al_to_scrap"])*df.loc['process emission','Aluminium - primary production']
 
 ### Other non-ferrous metals
 

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -1372,4 +1372,5 @@ sources=['elec','biomass', 'methane', 'hydrogen', 'heat','naphtha']
 df.loc[sources,sector] = df.loc[sources,sector]*conv_factor/s_out['Physical output (index)'] # unit MWh/t material
 
 
+df.index.name = "MWh/tMaterial"
 df.to_csv('resources/industry_sector_ratios.csv', sep=';')

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -655,7 +655,8 @@ def insert_electricity_distribution_grid(network):
                  lifetime=costs.at['electricity distribution grid','lifetime'],
                  capital_cost=costs.at['electricity distribution grid','fixed']*snakemake.config["sector"]['electricity_distribution_grid_cost_factor'])
 
-    loads = network.loads.index[network.loads.carrier=="electricity"]
+    #this catches regular electricity load and "industry new electricity"
+    loads = network.loads.index[network.loads.carrier.str.contains("electricity")]
     network.loads.loc[loads,"bus"] += " low voltage"
 
     bevs = network.links.index[network.links.carrier == "BEV charger"]


### PR DESCRIPTION
This makes clearer what the actual demand for steel, cement, chemicals, aluminium etc. in megatonne per year is in the model.
The split between primary and secondary is handled in an intermediary step which takes today's production routes (in industrial_production_per_country.csv in Mt/a) and calculates the ideal 2050 routes (in industrial_production_per_country_tomorrow.csv in Mt/a).
Also now industry_sector_ratios.csv represents the genuine energy demand in MWh per tonne material - there are no tricks for primary/secondary split manipulation anymore (this is taken care of in build_industrial_production_per_country_tomorrow).
Hopefully this is all more transparent.

This PR addresses Issue https://github.com/PyPSA/pypsa-eur-sec/issues/62.

Still to do:

- [x] Split ammonia demand out from "basic chemicals"
- [x] Create a file with today's energy demand per sector per country (from JRC-IDEES) for future pathway optimization
- [ ] Options to choose endogenously in model between BF+CCS and DRI+EAF in model