### PR TITLE
add EU oil bus already when adding land transport to be able to run t…

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1150,6 +1150,12 @@ def add_land_transport(network):
 
     if ice_share > 0:
 
+        if "EU oil" not in network.buses.index:
+            network.madd("Bus",
+                         ["EU oil"],
+                         location="EU",
+                         carrier="oil")
+
         network.madd("Load",
                      nodes,
                      suffix=" land transport oil",
@@ -1766,6 +1772,7 @@ def add_industry(network):
     #remove today's industrial electricity demand by scaling down total electricity demand
     for ct in n.buses.country.unique():
         loads = n.loads.index[(n.loads.index.str[:2] == ct) & (n.loads.carrier == "electricity")]
+        if n.loads_t.p_set[loads].empty: continue
         factor = 1 - industrial_demand.loc[loads,"current electricity"].sum()/n.loads_t.p_set[loads].sum().sum()
         n.loads_t.p_set[loads] *= factor
 


### PR DESCRIPTION
- add EU oil bus already in function add_land_transport(n) to avoid warning of missing bus for loads and being able to run the model without the industry sector
- when removing todays industrial electricity demand by scaling down total eletricity demand, remove "RuntimeWarning: invalid value encountered in double_scalars" by checking if the load is empty (for not dividing by zero)