### PR TITLE
Revision: build clustered population layouts

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -43,6 +43,7 @@ rule build_population_layouts:
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc"
     resources: mem_mb=20000
+    threads: 8
     script: "scripts/build_population_layouts.py"
 
 

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -25,4 +25,8 @@ if __name__ == '__main__':
 
     pop = pd.DataFrame(pop, index=clustered_regions.index)
 
+    node_country = pop.index.str[:2]
+    country_population = pop.total.groupby(node_country).sum()
+    pop["fraction"] = pop.total / node_country.map(country_population)
+
     pop.to_csv(snakemake.output.clustered_pop_layout)

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -1,3 +1,4 @@
+"""Build clustered population layouts."""
 
 import geopandas as gpd
 import xarray as xr
@@ -6,27 +7,29 @@ import atlite
 import helper
 
 
-cutout = atlite.Cutout(snakemake.config['atlite']['cutout_name'],
-                       cutout_dir=snakemake.config['atlite']['cutout_dir'])
+if __name__ == '__main__':
+
+    cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
+
+    clustered_busregions_as_geopd = gpd.read_file(
+        snakemake.input.regions_onshore).set_index('name', drop=True)
+
+    clustered_busregions = pd.Series(
+        clustered_busregions_as_geopd.geometry, index=clustered_busregions_as_geopd.index)
+
+    helper.clean_invalid_geometries(clustered_busregions)
+
+    I = cutout.indicatormatrix(clustered_busregions)
 
 
-clustered_busregions_as_geopd = gpd.read_file(snakemake.input.regions_onshore).set_index('name', drop=True)
+    items = ["total", "urban", "rural"]
 
-clustered_busregions = pd.Series(clustered_busregions_as_geopd.geometry, index=clustered_busregions_as_geopd.index)
-
-helper.clean_invalid_geometries(clustered_busregions)
-
-I = cutout.indicatormatrix(clustered_busregions)
+    pop = pd.DataFrame(columns=items,
+                    index=clustered_busregions.index)
 
 
-items = ["total","urban","rural"]
+    for item in items:
+        pop_layout = xr.open_dataarray(snakemake.input['pop_layout_'+item])
+        pop[item] = I.dot(pop_layout.stack(spatial=('y', 'x')))
 
-pop = pd.DataFrame(columns=items,
-                   index=clustered_busregions.index)
-
-
-for item in items:
-    pop_layout = xr.open_dataarray(snakemake.input['pop_layout_'+item])
-    pop[item] = I.dot(pop_layout.stack(spatial=('y', 'x')))
-
-pop.to_csv(snakemake.output.clustered_pop_layout)
+    pop.to_csv(snakemake.output.clustered_pop_layout)

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -4,32 +4,25 @@ import geopandas as gpd
 import xarray as xr
 import pandas as pd
 import atlite
-import helper
+from helper import clean_invalid_geometries
 
 
 if __name__ == '__main__':
 
     cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
 
-    clustered_busregions_as_geopd = gpd.read_file(
-        snakemake.input.regions_onshore).set_index('name', drop=True)
+    clustered_regions = gpd.read_file(
+        snakemake.input.regions_onshore).set_index('name').squeeze()
 
-    clustered_busregions = pd.Series(
-        clustered_busregions_as_geopd.geometry, index=clustered_busregions_as_geopd.index)
+    clean_invalid_geometries(clustered_regions)
 
-    helper.clean_invalid_geometries(clustered_busregions)
+    I = cutout.indicatormatrix(clustered_regions)
 
-    I = cutout.indicatormatrix(clustered_busregions)
-
-
-    items = ["total", "urban", "rural"]
-
-    pop = pd.DataFrame(columns=items,
-                    index=clustered_busregions.index)
-
-
-    for item in items:
-        pop_layout = xr.open_dataarray(snakemake.input['pop_layout_'+item])
+    pop = {}
+    for item in ["total", "urban", "rural"]:
+        pop_layout = xr.open_dataarray(snakemake.input[f'pop_layout_{item}'])
         pop[item] = I.dot(pop_layout.stack(spatial=('y', 'x')))
+
+    pop = pd.DataFrame(pop, index=clustered_regions.index)
 
     pop.to_csv(snakemake.output.clustered_pop_layout)

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     reference = ["RS", "BA"]
     average = urban_fraction[reference].mean()
     fill_values = pd.Series({ct: average for ct in missing})
-    urban_fraction.append(fill_values)
+    urban_fraction = urban_fraction.append(fill_values)
 
     # population in each grid cell
     pop_cells = pd.Series(I.dot(nuts3['pop']))

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -2,6 +2,7 @@
 
 import multiprocessing as mp
 import atlite
+import numpy as np
 import pandas as pd
 import xarray as xr
 import geopandas as gpd
@@ -36,7 +37,7 @@ if __name__ == '__main__':
     # but imprecisions mean not perfect
     Iinv = cutout.indicatormatrix(nuts3.geometry)
 
-    countries = nuts3.country.unique()
+    countries = np.sort(nuts3.country.unique())
 
     urban_fraction = pd.read_csv(snakemake.input.urban_percent,
                                 header=None, index_col=0,

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         pop_cells_ct = indicator_cells_ct * pop_cells
 
         # correct for imprecision of Iinv*I
-        pop_ct = nuts3['pop'].filter(like=ct).sum()
+        pop_ct = nuts3.loc[nuts3.country==ct,'pop'].sum()
         pop_cells_ct *= pop_ct / pop_cells_ct.sum()
 
         # The first low density grid cells to reach rural fraction are rural

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -1,103 +1,100 @@
-
-# Build mapping between grid cells and population (total, urban, rural)
+"""Build mapping between grid cells and population (total, urban, rural)"""
 
 import atlite
 import pandas as pd
 import xarray as xr
+import geopandas as gpd
 
 from vresutils import shapes as vshapes
 
-import geopandas as gpd
+if __name__ == '__main__':
 
+    if 'snakemake' not in globals():
+        from vresutils import Dict
+        import yaml
+        snakemake = Dict()
+        with open('config.yaml') as f:
+            snakemake.config = yaml.safe_load(f)
+        snakemake.input = Dict()
+        snakemake.output = Dict()
 
-if 'snakemake' not in globals():
-    from vresutils import Dict
-    import yaml
-    snakemake = Dict()
-    with open('config.yaml') as f:
-        snakemake.config = yaml.safe_load(f)
-    snakemake.input = Dict()
-    snakemake.output = Dict()
+        snakemake.input["urban_percent"] = "data/urban_percent.csv"
 
-    snakemake.input["urban_percent"] = "data/urban_percent.csv"
+    cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
 
-cutout = atlite.Cutout(snakemake.config['atlite']['cutout_name'],
-                       cutout_dir=snakemake.config['atlite']['cutout_dir'])
+    grid_cells = cutout.grid_cells()
 
-grid_cells = cutout.grid_cells()
+    # nuts3 has columns country, gdp, pop, geometry
+    # population is given in dimensions of 1e3=k
+    nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index('index')
 
-#nuts3 has columns country, gdp, pop, geometry
-#population is given in dimensions of 1e3=k
-nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index('index')
+    # Indicator matrix NUTS3 -> grid cells
+    I = atlite.cutout.compute_indicatormatrix(nuts3.geometry, grid_cells)
 
+    # Indicator matrix grid_cells -> NUTS3; inprinciple Iinv*I is identity
+    # but imprecisions mean not perfect
+    Iinv = cutout.indicatormatrix(nuts3.geometry)
 
-# Indicator matrix NUTS3 -> grid cells
-I = atlite.cutout.compute_indicatormatrix(nuts3.geometry, grid_cells)
+    countries = nuts3.country.value_counts().index.sort_values()
 
-# Indicator matrix grid_cells -> NUTS3; inprinciple Iinv*I is identity
-# but imprecisions mean not perfect
-Iinv = cutout.indicatormatrix(nuts3.geometry)
+    urban_fraction = pd.read_csv(snakemake.input.urban_percent,
+                                 header=None, index_col=0, squeeze=True) / 100.
 
-countries = nuts3.country.value_counts().index.sort_values()
+    # fill missing Balkans values
+    missing = ["AL", "ME", "MK"]
+    reference = ["RS", "BA"]
+    urban_fraction = urban_fraction.reindex(
+        urban_fraction.index.union(missing))
+    urban_fraction.loc[missing] = urban_fraction[reference].mean()
 
-urban_fraction = pd.read_csv(snakemake.input.urban_percent,
-                             header=None,index_col=0,squeeze=True)/100.
+    # population in each grid cell
+    pop_cells = pd.Series(I.dot(nuts3['pop']))
 
-#fill missing Balkans values
-missing = ["AL","ME","MK"]
-reference = ["RS","BA"]
-urban_fraction = urban_fraction.reindex(urban_fraction.index.union(missing))
-urban_fraction.loc[missing] = urban_fraction[reference].mean()
+    # in km^2
+    cell_areas = pd.Series(cutout.grid_cells()).map(vshapes.area) / 1e6
 
+    # pop per km^2
+    density_cells = pop_cells / cell_areas
 
-#population in each grid cell
-pop_cells = pd.Series(I.dot(nuts3['pop']))
+    # rural or urban population in grid cell
+    pop_rural = pd.Series(0., density_cells.index)
+    pop_urban = pd.Series(0., density_cells.index)
 
-#in km^2
-cell_areas = pd.Series(cutout.grid_cells()).map(vshapes.area)/1e6
+    for ct in countries:
+        print(ct, urban_fraction[ct])
 
-#pop per km^2
-density_cells = pop_cells/cell_areas
+        indicator_nuts3_ct = pd.Series(0., nuts3.index)
+        indicator_nuts3_ct[nuts3.index[nuts3.country == ct]] = 1.
 
+        indicator_cells_ct = pd.Series(Iinv.T.dot(indicator_nuts3_ct))
 
-#rural or urban population in grid cell
-pop_rural = pd.Series(0.,density_cells.index)
-pop_urban = pd.Series(0.,density_cells.index)
+        density_cells_ct = indicator_cells_ct * density_cells
 
-for ct in countries:
-    print(ct,urban_fraction[ct])
+        pop_cells_ct = indicator_cells_ct * pop_cells
 
-    indicator_nuts3_ct = pd.Series(0.,nuts3.index)
-    indicator_nuts3_ct[nuts3.index[nuts3.country==ct]] = 1.
+        # correct for imprecision of Iinv*I
+        pop_ct = nuts3['pop'][indicator_nuts3_ct.index[indicator_nuts3_ct == 1.]].sum()
+        pop_cells_ct = pop_cells_ct * pop_ct / pop_cells_ct.sum()
 
-    indicator_cells_ct = pd.Series(Iinv.T.dot(indicator_nuts3_ct))
+        # The first low density grid cells to reach rural fraction are rural
+        index_from_low_d_to_high_d = density_cells_ct.sort_values().index
+        pop_ct_rural_b = pop_cells_ct[index_from_low_d_to_high_d].cumsum(
+        ) / pop_cells_ct.sum() < (1 - urban_fraction[ct])
+        pop_ct_urban_b = ~pop_ct_rural_b
 
-    density_cells_ct = indicator_cells_ct*density_cells
+        pop_ct_rural_b[indicator_cells_ct == 0.] = False
+        pop_ct_urban_b[indicator_cells_ct == 0.] = False
 
-    pop_cells_ct = indicator_cells_ct*pop_cells
+        pop_rural += pop_cells_ct.where(pop_ct_rural_b, 0.)
+        pop_urban += pop_cells_ct.where(pop_ct_urban_b, 0.)
 
-    #correct for imprecision of Iinv*I
-    pop_ct = nuts3['pop'][indicator_nuts3_ct.index[indicator_nuts3_ct == 1.]].sum()
-    pop_cells_ct = pop_cells_ct*pop_ct/pop_cells_ct.sum()
+    pop_cells = {"total": pop_cells}
 
-    # The first low density grid cells to reach rural fraction are rural
-    index_from_low_d_to_high_d = density_cells_ct.sort_values().index
-    pop_ct_rural_b = pop_cells_ct[index_from_low_d_to_high_d].cumsum()/pop_cells_ct.sum() < (1-urban_fraction[ct])
-    pop_ct_urban_b = ~pop_ct_rural_b
+    pop_cells["rural"] = pop_rural
+    pop_cells["urban"] = pop_urban
 
-    pop_ct_rural_b[indicator_cells_ct==0.] = False
-    pop_ct_urban_b[indicator_cells_ct==0.] = False
+    for key in pop_cells.keys():
+        layout = xr.DataArray(pop_cells[key].values.reshape(cutout.shape),
+                              [('y', cutout.coords['y']), ('x', cutout.coords['x'])])
 
-    pop_rural += pop_cells_ct.where(pop_ct_rural_b,0.)
-    pop_urban += pop_cells_ct.where(pop_ct_urban_b,0.)
-
-pop_cells = {"total" : pop_cells}
-
-pop_cells["rural"] = pop_rural
-pop_cells["urban"] = pop_urban
-
-for key in pop_cells.keys():
-    layout = xr.DataArray(pop_cells[key].values.reshape(cutout.shape),
-                          [('y', cutout.coords['y']), ('x', cutout.coords['x'])])
-
-    layout.to_netcdf(snakemake.output["pop_layout_"+key])
+        layout.to_netcdf(snakemake.output["pop_layout_"+key])


### PR DESCRIPTION
depends on #108 

## Changes

No change in functionality, but move code into `__main__` and make GeoDataframe a  GeoSeries that can be passed to the `clean_invalid_geometries` function without conversion to a `pd.Series`.

## To test

```py
import pandas as pd
import geopandas as gpd
import matplotlib.pyplot as plt
plt.style.use('ggplot')

fn = "pop_layout_elec_s_60.csv"
fn_gdf = "regions_onshore_elec_s_60.geojson"

old = pd.read_csv("old_"+fn, index_col=0)
old_gdf = gpd.read_file("old_"+fn_gdf).set_index('name')
old = old_gdf.join(old)

new = pd.read_csv(fn, index_col=0)
new_gdf = gpd.read_file(fn_gdf).set_index('name')
new = new_gdf.join(new)

# visual inspection, because bus labels inside country may be different
for item in ["total", "rural", "urban"]:
    fig, ax = plt.subplots(1,2, figsize=(10,5))
    fig.suptitle(item)
    vmax = 35000
    old.plot(item, ax=ax[0], vmax=vmax)
    ax[0].set_title('old')
    new.plot(item, ax=ax[1], vmax=vmax)
    ax[1].set_title('new')
```


[clustered_population_layouts.zip](https://github.com/PyPSA/pypsa-eur-sec/files/6433832/clustered_population_layouts.zip)
