### PR TITLE
retro: fix renaming u_values subsectors and btype

### DIFF
--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -253,7 +253,8 @@ def prepare_building_stock_data():
                   axis=1, inplace=True, errors="ignore")
 
 
-    u_values = u_values.apply(lambda x: x.replace(rename_sectors))
+    u_values.subsector.replace(rename_sectors, inplace=True)
+    u_values.btype.replace(rename_sectors, inplace=True)
 
     # for missing weighting of surfaces of building types assume MFH
     u_values["assumed_subsector"] = u_values.subsector


### PR DESCRIPTION
by not looping the .replace() across all columns of the dataframe.

Circumvents: TypeError: Cannot compare types 'ndarray(dtype=float64)' and 'str'