### PR TITLE
Revision: use `mock_snakemake` from pypsa-eur

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -77,24 +77,16 @@ def add_brownfield(n, n_p, year):
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils.snakemake import MockSnakemake
-        snakemake = MockSnakemake(
-            wildcards=dict(network='elec', simpl='', clusters='37', lv='1.0',
-                           sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-                           co2_budget_name='go',
-                           planning_horizons='2030'),
-            input=dict(network='pypsa-eur-sec/results/test/prenetworks/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{co2_budget_name}_{planning_horizons}.nc',
-                       network_p='pypsa-eur-sec/results/test/postnetworks/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{co2_budget_name}_2020.nc',
-                       costs='pypsa-eur-sec/data/costs/costs_{planning_horizons}.csv',
-                       cop_air_total="pypsa-eur-sec/resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
-                       cop_soil_total="pypsa-eur-sec/resources/cop_soil_total_elec_s{simpl}_{clusters}.nc"),
-            output=['pypsa-eur-sec/results/test/prenetworks_brownfield/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{planning_horizons}.nc']
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'add_brownfield',
+            simpl='',
+            clusters=48,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            planning_horizons=2030,
         )
-        import yaml
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
 
     print(snakemake.input.network_p)
     logging.basicConfig(level=snakemake.config['logging_level'])

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -403,27 +403,16 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils.snakemake import MockSnakemake
-        snakemake = MockSnakemake(
-            wildcards=dict(network='elec', simpl='', clusters='45', lv='1.0',
-                           sector_opts='Co2L0-3H-T-H-B-I-solar3-dist1',
-                           planning_horizons='2020'),
-            input=dict(network='pypsa-eur-sec/results/version-2/prenetworks/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{planning_horizons}.nc',
-                       powerplants='pypsa-eur/resources/powerplants.csv',
-                       busmap_s='pypsa-eur/resources/busmap_elec_s{simpl}.csv',
-                       busmap='pypsa-eur/resources/busmap_elec_s{simpl}_{clusters}.csv',
-                       costs='technology_data/outputs/costs_{planning_horizons}.csv',
-                       cop_air_total="pypsa-eur-sec/resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
-                       cop_soil_total="pypsa-eur-sec/resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-                       clustered_pop_layout="pypsa-eur-sec/resources/pop_layout_elec_s{simpl}_{clusters}.csv",),
-            output=['pypsa-eur-sec/results/version-2/prenetworks_brownfield/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{planning_horizons}.nc'],
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'add_existing_baseyear',
+            simpl='',
+            clusters=45,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            planning_horizons=2020,
         )
-        import yaml
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
-
 
     logging.basicConfig(level=snakemake.config['logging_level'])
 

--- a/scripts/build_ammonia_production.py
+++ b/scripts/build_ammonia_production.py
@@ -28,6 +28,9 @@ country_to_alpha2 = {
 }
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_ammonia_production')
 
     ammonia = pd.read_excel(snakemake.input.usgs,
                             sheet_name="T12",

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -53,20 +53,9 @@ def build_biomass_potentials():
 
 
 if __name__ == "__main__":
-
-
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        snakemake.input = Dict()
-        snakemake.input['jrc_potentials'] = "data/biomass/JRC Biomass Potentials.xlsx"
-        snakemake.output = Dict()
-        snakemake.output['biomass_potentials'] = 'data/biomass_potentials.csv'
-        snakemake.output['biomass_potentials_all']='resources/biomass_potentials_all.csv'
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_biomass_potentials')
 
 
     # This is a hack, to be replaced once snakemake is unicode-conform

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -7,6 +7,13 @@ import atlite
 
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_clustered_population_layouts',
+            simpl='',
+            clusters=48,
+        )
 
     cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
 

--- a/scripts/build_cop_profiles.py
+++ b/scripts/build_cop_profiles.py
@@ -18,6 +18,13 @@ def coefficient_of_performance(delta_T, source='air'):
 
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_cop_profiles',
+            simpl='',
+            clusters=48,
+        )
 
     for area in ["total", "urban", "rural"]:
 

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -628,19 +628,9 @@ def build_transport_data(countries, population, idees):
 
 
 if __name__ == "__main__":
-
-    # Detect running outside of snakemake and mock snakemake for testing
-    if "snakemake" not in globals():
-        from vresutils import Dict
-
-        snakemake = Dict()
-        snakemake.output = Dict()
-        snakemake.output["energy_name"] = "data/energy_totals.csv"
-        snakemake.output["co2_name"] = "data/co2_totals.csv"
-        snakemake.output["transport_name"] = "data/transport_data.csv"
-
-        snakemake.input = Dict()
-        snakemake.input["nuts3_shapes"] = "../pypsa-eur/resources/nuts3_shapes.geojson"
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_energy_totals')
 
     config = snakemake.config["energy"]
 

--- a/scripts/build_heat_demand.py
+++ b/scripts/build_heat_demand.py
@@ -7,6 +7,13 @@ import xarray as xr
 import numpy as np
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_heat_demands',
+            simpl='',
+            clusters=48,
+        )
 
     if 'snakemake' not in globals():
         from vresutils import Dict

--- a/scripts/build_industrial_distribution_key.py
+++ b/scripts/build_industrial_distribution_key.py
@@ -108,6 +108,13 @@ def build_nodal_distribution_key(hotmaps, regions):
 
 
 if __name__ == "__main__":
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_industrial_distribution_key',
+            simpl='',
+            clusters=48,
+        )
 
     regions = gpd.read_file(snakemake.input.regions_onshore).set_index('name')
 

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -141,6 +141,9 @@ def industrial_energy_demand(countries):
 
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_industrial_energy_demand_per_country_today')
 
     config = snakemake.config['industry']
     year = config.get('reference_year', 2015)

--- a/scripts/build_industrial_energy_demand_per_node.py
+++ b/scripts/build_industrial_energy_demand_per_node.py
@@ -3,6 +3,13 @@
 import pandas as pd
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_industrial_energy_demand_per_node',
+            simpl='',
+            clusters=48,
+        )
         
     # import EU ratios df as csv
     fn = snakemake.input.industry_sector_ratios

--- a/scripts/build_industrial_energy_demand_per_node_today.py
+++ b/scripts/build_industrial_energy_demand_per_node_today.py
@@ -62,5 +62,12 @@ def build_nodal_industrial_energy_demand():
 
 
 if __name__ == "__main__":
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_industrial_energy_demand_per_node_today',
+            simpl='',
+            clusters=48,
+        )
 
     build_nodal_industrial_energy_demand()

--- a/scripts/build_industrial_production_per_country.py
+++ b/scripts/build_industrial_production_per_country.py
@@ -203,6 +203,9 @@ def add_ammonia_demand_separately(demand):
 
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_industrial_production_per_country')
 
     countries = non_EU + eu28
 

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -3,6 +3,9 @@
 import pandas as pd
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_industrial_production_per_country_tomorrow')
 
     config = snakemake.config["industry"]
 

--- a/scripts/build_industrial_production_per_node.py
+++ b/scripts/build_industrial_production_per_node.py
@@ -53,5 +53,11 @@ def build_nodal_industrial_production():
 
 
 if __name__ == "__main__":
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_industrial_production_per_node',
+            simpl='',
+            clusters=48,
+        )
 
     build_nodal_industrial_production()

--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -1430,6 +1430,9 @@ def other_industrial_sectors():
 
 
 if __name__ == "__main__":
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_industry_sector_ratios')
 
     # TODO make config option
     year = 2015

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -10,17 +10,9 @@ import geopandas as gpd
 from vresutils import shapes as vshapes
 
 if __name__ == '__main__':
-
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        with open('config.yaml') as f:
-            snakemake.config = yaml.safe_load(f)
-        snakemake.input = Dict()
-        snakemake.output = Dict()
-
-        snakemake.input["urban_percent"] = "data/urban_percent.csv"
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('build_population_layouts')
 
     cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
 

--- a/scripts/build_retro_cost.py
+++ b/scripts/build_retro_cost.py
@@ -825,36 +825,15 @@ def sample_dE_costs_area(area, area_tot, costs, dE_space, countries,
 
 #%% --- MAIN --------------------------------------------------------------
 if __name__ == "__main__":
-    #  for testing
     if 'snakemake' not in globals():
-        import yaml
-        import os
-        from vresutils.snakemake import MockSnakemake
-        snakemake = MockSnakemake(
-            wildcards=dict(
-                network='elec',
-                simpl='',
-                clusters='48',
-                lv='1',
-                opts='Co2L-3H',
-                sector_opts="[Co2L0p0-168H-T-H-B-I]"),
-            input=dict(
-                building_stock="data/retro/data_building_stock.csv",
-                data_tabula="data/retro/tabula-calculator-calcsetbuilding.csv",
-                u_values_PL="data/retro/u_values_poland.csv",
-                air_temperature = "resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-                tax_w="data/retro/electricity_taxes_eu.csv",
-                construction_index="data/retro/comparative_level_investment.csv",
-                floor_area_missing="data/retro/floor_area_missing.csv",
-                clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
-                cost_germany="data/retro/retro_cost_germany.csv",
-                window_assumptions="data/retro/window_assumptions.csv"),
-            output=dict(
-                retro_cost="resources/retro_cost_elec_s{simpl}_{clusters}.csv",
-                floor_area="resources/floor_area_elec_s{simpl}_{clusters}.csv")
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_retro_cost',
+            simpl='',
+            clusters=48,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1'
         )
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
 
 #  ********  config  *********************************************************
 

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -7,6 +7,13 @@ import xarray as xr
 import numpy as np
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_solar_thermal_profiles',
+            simpl='',
+            clusters=48,
+        )
 
     if 'snakemake' not in globals():
         from vresutils import Dict

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -7,15 +7,13 @@ import xarray as xr
 import numpy as np
 
 if __name__ == '__main__':
-
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        with open('config.yaml') as f:
-            snakemake.config = yaml.safe_load(f)
-        snakemake.input = Dict()
-        snakemake.output = Dict()
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'build_temperature_profiles',
+            simpl='',
+            clusters=48,
+        )
 
     time = pd.date_range(freq='h', **snakemake.config['snapshots'])
     cutout_config = snakemake.config['atlite']['cutout']

--- a/scripts/copy_config.py
+++ b/scripts/copy_config.py
@@ -9,6 +9,9 @@ files = [
 ]
 
 if __name__ == '__main__':
+    if 'snakemake' not in globals():
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('copy_config')
 
     for f in files:
         copy(f,snakemake.config['summary_dir'] + '/' + snakemake.config['run'] + '/configs/')

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+from pathlib import Path
 from pypsa.descriptors import Dict
 from pypsa.components import components, component_attrs
 
@@ -33,3 +34,58 @@ def override_component_attrs(directory):
             attrs[component] = overrides.combine_first(attrs[component])
 
     return attrs
+
+
+# from pypsa-eur/_helpers.py
+def mock_snakemake(rulename, **wildcards):
+    """
+    This function is expected to be executed from the 'scripts'-directory of '
+    the snakemake project. It returns a snakemake.script.Snakemake object,
+    based on the Snakefile.
+
+    If a rule has wildcards, you have to specify them in **wildcards.
+
+    Parameters
+    ----------
+    rulename: str
+        name of the rule for which the snakemake object should be generated
+    **wildcards:
+        keyword arguments fixing the wildcards. Only necessary if wildcards are
+        needed.
+    """
+    import snakemake as sm
+    import os
+    from pypsa.descriptors import Dict
+    from snakemake.script import Snakemake
+
+    script_dir = Path(__file__).parent.resolve()
+    assert Path.cwd().resolve() == script_dir, \
+      f'mock_snakemake has to be run from the repository scripts directory {script_dir}'
+    os.chdir(script_dir.parent)
+    for p in sm.SNAKEFILE_CHOICES:
+        if os.path.exists(p):
+            snakefile = p
+            break
+    workflow = sm.Workflow(snakefile)
+    workflow.include(snakefile)
+    workflow.global_resources = {}
+    rule = workflow.get_rule(rulename)
+    dag = sm.dag.DAG(workflow, rules=[rule])
+    wc = Dict(wildcards)
+    job = sm.jobs.Job(rule, dag, wc)
+
+    def make_accessable(*ios):
+        for io in ios:
+            for i in range(len(io)):
+                io[i] = os.path.abspath(io[i])
+
+    make_accessable(job.input, job.output, job.log)
+    snakemake = Snakemake(job.input, job.output, job.params, job.wildcards,
+                          job.threads, job.resources, job.log,
+                          job.dag.workflow.config, job.rule.name, None,)
+    # create log and output dir if not existent
+    for path in list(snakemake.log) + list(snakemake.output):
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+    os.chdir(script_dir)
+    return snakemake

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -557,39 +557,20 @@ def to_csv(df):
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
-
-        #overwrite some options
-        snakemake.config["run"] = "version-8"
-        snakemake.config["scenario"]["lv"] = [1.0]
-        snakemake.config["scenario"]["sector_opts"] = ["3H-T-H-B-I-solar3-dist1"]
-        snakemake.config["planning_horizons"] = ['2020', '2030', '2040', '2050']
-        snakemake.input = Dict()
-        snakemake.input['costs'] = snakemake.config['costs_dir'] + "costs_{}.csv".format(snakemake.config['scenario']['planning_horizons'][0])
-        snakemake.output = Dict()
-        for item in outputs:
-            snakemake.output[item] = snakemake.config['summary_dir'] + '/{name}/csvs/{item}.csv'.format(name=snakemake.config['run'],item=item)
-        snakemake.output['cumulative_cost'] = snakemake.config['summary_dir'] + '/{name}/csvs/cumulative_cost.csv'.format(name=snakemake.config['run'])
-    networks_dict = {(cluster, lv, opt+sector_opt, planning_horizon) :
-                     snakemake.config['results_dir'] + snakemake.config['run'] + '/postnetworks/elec_s{simpl}_{cluster}_lv{lv}_{opt}_{sector_opt}_{planning_horizon}.nc'\
-                     .format(simpl=simpl,
-                             cluster=cluster,
-                             opt=opt,
-                             lv=lv,
-                             sector_opt=sector_opt,
-                             planning_horizon=planning_horizon)\
-                     for simpl in snakemake.config['scenario']['simpl'] \
-                     for cluster in snakemake.config['scenario']['clusters'] \
-                     for opt in snakemake.config['scenario']['opts'] \
-                     for sector_opt in snakemake.config['scenario']['sector_opts'] \
-                     for lv in snakemake.config['scenario']['lv'] \
-                     for planning_horizon in snakemake.config['scenario']['planning_horizons']}
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('make_summary')
+    
+    networks_dict = {
+        (cluster, lv, opt+sector_opt, planning_horizon) :
+        snakemake.config['results_dir'] + snakemake.config['run'] + f'/postnetworks/elec_s{simpl}_{cluster}_lv{lv}_{opt}_{sector_opt}_{planning_horizon}.nc' \
+        for simpl in snakemake.config['scenario']['simpl'] \
+        for cluster in snakemake.config['scenario']['clusters'] \
+        for opt in snakemake.config['scenario']['opts'] \
+        for sector_opt in snakemake.config['scenario']['sector_opts'] \
+        for lv in snakemake.config['scenario']['lv'] \
+        for planning_horizon in snakemake.config['scenario']['planning_horizons']
+    }
 
     print(networks_dict)
 

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -517,34 +517,16 @@ def plot_series(network, carrier="AC", name="test"):
 
 
 if __name__ == "__main__":
-
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        with open('config.yaml') as f:
-            snakemake.config = yaml.safe_load(f)
-        snakemake.config['run'] = "retro_vs_noretro"
-        snakemake.wildcards = {"lv": "1.0"}  # lv1.0, lv1.25, lvopt
-        name = "elec_s_48_lv{}__Co2L0-3H-T-H-B".format(snakemake.wildcards["lv"])
-        suffix = "_retro_tes"
-        name = name + suffix
-        snakemake.input = Dict()
-        snakemake.output = Dict(
-            map=(snakemake.config['results_dir'] + snakemake.config['run']
-                 + "/maps/{}".format(name)),
-            today=(snakemake.config['results_dir'] + snakemake.config['run']
-                   + "/maps/{}.pdf".format(name)))
-        snakemake.input.scenario = "lv" + snakemake.wildcards["lv"]
-#        snakemake.config["run"] = "bio_costs"
-        path = snakemake.config['results_dir'] + snakemake.config['run']
-        snakemake.input.network = (path +
-                                   "/postnetworks/{}.nc"
-                                   .format(name))
-        snakemake.output.network = (path +
-                                    "/maps/{}"
-                                    .format(name))
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'plot_network',
+            simpl='',
+            clusters=48,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            planning_horizons=2050,
+        )
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -431,24 +431,9 @@ def plot_carbon_budget_distribution():
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils import Dict
-        import yaml
-        snakemake = Dict()
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
-        snakemake.input = Dict()
-        snakemake.output = Dict()
-        snakemake.wildcards = Dict()
-        #snakemake.wildcards['sector_opts']='3H-T-H-B-I-solar3-dist1-cb48be3'        
-        
-        for item in ["costs", "energy"]:
-            snakemake.input[item] = snakemake.config['summary_dir'] + '/{name}/csvs/{item}.csv'.format(name=snakemake.config['run'],item=item)
-            snakemake.output[item] = snakemake.config['summary_dir'] + '/{name}/graphs/{item}.pdf'.format(name=snakemake.config['run'],item=item)
-        snakemake.input["balances"] = snakemake.config['summary_dir'] + '/{name}/csvs/supply_energy.csv'.format(name=snakemake.config['run'],item=item)
-        snakemake.output["balances"] = snakemake.config['summary_dir'] + '/{name}/graphs/balances-energy.csv'.format(name=snakemake.config['run'],item=item)
-        
+        from helper import mock_snakemake
+        snakemake = mock_snakemake('plot_summary')
         
     n_header = 4
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1815,58 +1815,16 @@ def get_parameter(item):
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils.snakemake import MockSnakemake
-        snakemake = MockSnakemake(
-            wildcards=dict(network='elec', simpl='', clusters='37', lv='1.0',
-                           opts='', planning_horizons='2020',
-                           sector_opts='120H-T-H-B-I-onwind+p3-dist1-cb48be3'),
-
-            input=dict( network='../pypsa-eur/networks/elec_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc',
-                        energy_totals_name='resources/energy_totals.csv',
-                        co2_totals_name='resources/co2_totals.csv',
-                        transport_name='resources/transport_data.csv',
-                	    traffic_data = "data/emobility/",
-                        biomass_potentials='resources/biomass_potentials.csv',
-                        timezone_mappings='data/timezone_mappings.csv',
-                        heat_profile="data/heat_load_profile_BDEW.csv",
-                        costs="../technology-data/outputs/costs_{planning_horizons}.csv",
-                	    h2_cavern = "data/hydrogen_salt_cavern_potentials.csv",
-                        profile_offwind_ac="../pypsa-eur/resources/profile_offwind-ac.nc",
-                        profile_offwind_dc="../pypsa-eur/resources/profile_offwind-dc.nc",
-                        busmap_s="../pypsa-eur/resources/busmap_elec_s{simpl}.csv",
-                        busmap="../pypsa-eur/resources/busmap_elec_s{simpl}_{clusters}.csv",
-                        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
-                        simplified_pop_layout="resources/pop_layout_elec_s{simpl}.csv",
-                        industrial_demand="resources/industrial_energy_demand_elec_s{simpl}_{clusters}.csv",
-                        heat_demand_urban="resources/heat_demand_urban_elec_s{simpl}_{clusters}.nc",
-                        heat_demand_rural="resources/heat_demand_rural_elec_s{simpl}_{clusters}.nc",
-                        heat_demand_total="resources/heat_demand_total_elec_s{simpl}_{clusters}.nc",
-                        temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
-                        temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
-                        temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
-                        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-                        temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
-                        temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc",
-                        cop_soil_total="resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-                        cop_soil_rural="resources/cop_soil_rural_elec_s{simpl}_{clusters}.nc",
-                        cop_soil_urban="resources/cop_soil_urban_elec_s{simpl}_{clusters}.nc",
-                        cop_air_total="resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
-                        cop_air_rural="resources/cop_air_rural_elec_s{simpl}_{clusters}.nc",
-                        cop_air_urban="resources/cop_air_urban_elec_s{simpl}_{clusters}.nc",
-                        solar_thermal_total="resources/solar_thermal_total_elec_s{simpl}_{clusters}.nc",
-                        solar_thermal_urban="resources/solar_thermal_urban_elec_s{simpl}_{clusters}.nc",
-                        solar_thermal_rural="resources/solar_thermal_rural_elec_s{simpl}_{clusters}.nc",
-                	    retro_cost_energy = "resources/retro_cost_elec_s{simpl}_{clusters}.csv",
-                        floor_area = "resources/floor_area_elec_s{simpl}_{clusters}.csv"
-            ),
-            output=['results/version-cb48be3/prenetworks/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{planning_horizons}.nc']
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'prepare_sector_network',
+            simpl='',
+            clusters=48,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            planning_horizons=2020,
         )
-        import yaml
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
-
 
     logging.basicConfig(level=snakemake.config['logging_level'])
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -193,21 +193,16 @@ def solve_network(n, config, opts='', **kwargs):
 
 
 if __name__ == "__main__":
-    # Detect running outside of snakemake and mock snakemake for testing
     if 'snakemake' not in globals():
-        from vresutils.snakemake import MockSnakemake, Dict
-        snakemake = MockSnakemake(
-            wildcards=dict(network='elec', simpl='', clusters='39', lv='1.0',
-                           sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-                           co2_budget_name='b30b3', planning_horizons='2050'),
-            input=dict(network="pypsa-eur-sec/results/test/prenetworks_brownfield/elec_s{simpl}_{clusters}_lv{lv}__{sector_opts}_{co2_budget_name}_{planning_horizons}.nc"),
-            output=["results/networks/s{simpl}_{clusters}_lv{lv}_{sector_opts}_{co2_budget_name}_{planning_horizons}-test.nc"],
-            log=dict(gurobi="logs/elec_s{simpl}_{clusters}_lv{lv}_{sector_opts}_{co2_budget_name}_{planning_horizons}_gurobi-test.log",
-                     python="logs/elec_s{simpl}_{clusters}_lv{lv}_{sector_opts}_{co2_budget_name}_{planning_horizons}_python-test.log")
+        from helper import mock_snakemake
+        snakemake = mock_snakemake(
+            'solve_network',
+            simpl='',
+            clusters=48,
+            lv=1.0,
+            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            planning_horizons=2050,
         )
-        import yaml
-        with open('config.yaml', encoding='utf8') as f:
-            snakemake.config = yaml.safe_load(f)
 
     logging.basicConfig(filename=snakemake.log.python,
                         level=snakemake.config['logging_level'])


### PR DESCRIPTION
Using the `mock_snakemake` from `pypsa-eur/_helpers.py` to run scripts outside snakemake reduces maintenance effort because input and output file names do not have to be modified twice. The function is temporarily copied into `scripts/helper.py` because of complex file dependencies.