### PR TITLE
Spatial management for solid biomass (transport)

### DIFF
--- a/scripts/build_biomass_transport_costs.py
+++ b/scripts/build_biomass_transport_costs.py
@@ -67,4 +67,4 @@ def build_biomass_transport_costs():
 
 if __name__ == "__main__":
 
-    prepare_biomass_transport_costs()
+    build_biomass_transport_costs()

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2094,6 +2094,8 @@ if __name__ == "__main__":
 
     patch_electricity_network(n)
 
+    define_spatial(pop_layout.index)
+
     if snakemake.config["foresight"] == 'myopic':
         
         add_lifetime_wind_solar(n, costs)


### PR DESCRIPTION
Similar to #148 manage the spatial resolution of solid biomass (copperplated or with biomass transport) through a namespace (think: global dictionary).

This allows to easily vary the spatial resolution of biomass in the model without removing components that are added inside the same script.

Currently the option `biomass_transport` triggers both spatial resolution of biomass as well as the transport of biomass. One could split this into two options.

PR against https://github.com/PyPSA/pypsa-eur-sec/tree/biomass-transport