### PR TITLE
Omitting unnecessary constraints on the CHP units

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -151,7 +151,7 @@ def add_chp_constraints(n):
 
 
 def extra_functionality(n, snapshots):
-    add_chp_constraints(n)
+    #add_chp_constraints(n)  # these constraints are currently unnecessary since all CHPs operate on the backpressure line. 
     add_battery_constraints(n)
 
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -151,7 +151,6 @@ def add_chp_constraints(n):
 
 
 def extra_functionality(n, snapshots):
-    #add_chp_constraints(n)  # these constraints are currently unnecessary since all CHPs operate on the backpressure line. 
     add_battery_constraints(n)
 
 


### PR DESCRIPTION
All CHPs in pypsa-eur-sec are operating on the backpressure line and this set of extra constraints to ensure working in the operational space of the CHPs is hence not necessary at the moment.