### PR TITLE
Update plot_network.py

### DIFF
--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -398,7 +398,8 @@ def plot_series(network, carrier="AC", name="test"):
 
     supply = pd.DataFrame(index=n.snapshots)
     for c in n.iterate_components(n.branch_components):
-        for i in range(2):
+        n_port = 4 if c.name=='Link' else 2
+        for i in range(n_port):
             supply = pd.concat((supply,
                                 (-1) * c.pnl["p" + str(i)].loc[:,
                                                                c.df.index[c.df["bus" + str(i)].isin(buses)]].groupby(c.df.carrier,


### PR DESCRIPTION
Some links producing heat have more than 2 ports (e.g. Fischer-Tropsch). This enables capturing them when plotting heat time series.

@fneum I'll create three pull requests with fixes to small issues so that they can be easily integrated.