### PR TITLE
fix-build_carbon_budget

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -103,9 +103,6 @@ def build_carbon_budget(o, fn):
     #emissions at the beginning of the path (last year available 2018)
     e_0 = co2_emissions_year(countries, opts, year=2018)
     
-    #emissions in 2019 and 2020 assumed equal to 2018 and substracted
-    carbon_budget -= 2 * e_0
-    
     planning_horizons = snakemake.config['scenario']['planning_horizons']
     t_0 = planning_horizons[0]
 


### PR DESCRIPTION
In the IPCC 6th Assessment Report, carbon budgets are reported from 2020 onwards.
See Table SPM2 in the Summary for Policymakers
https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_SPM.pdf 

Before carbon budgets were reported from 2018 onwards. Substracting emissions in 2018 and 2019 is no longer required. 