### PR TITLE
Add lifetime to solar-rooftop

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -770,7 +770,8 @@ def insert_electricity_distribution_grid(n, costs):
         marginal_cost=n.generators.loc[solar, 'marginal_cost'],
         capital_cost=costs.at['solar-rooftop', 'fixed'],
         efficiency=n.generators.loc[solar, 'efficiency'],
-        p_max_pu=n.generators_t.p_max_pu[solar]
+        p_max_pu=n.generators_t.p_max_pu[solar],
+        lifetime=costs.at['solar-rooftop', 'lifetime']   
     )
 
     n.add("Carrier", "home battery")


### PR DESCRIPTION
Rooftop-solar generators are missing the lifetime attribute when they are added.

This avoids that they are saved as brownfield capacities installed in a previous timestep when running myopic optimization. 
I.e, they are not captured in the following line
https://github.com/PyPSA/pypsa-eur-sec/blob/5b9f64354fb8cb6a8d9bfca361b5397347309ab3/scripts/add_existing_baseyear.py#L31