### PR TITLE
add basic setup of rsync with files to ignore

### DIFF
--- a/.syncignore-receive
+++ b/.syncignore-receive
@@ -1,0 +1,14 @@
+.snakemake
+.git
+.pytest_cache
+.ipynb_checkpoints
+.vscode
+.DS_Store
+__pycache__
+*.pyc
+*.pyo
+*.ipynb
+data
+notebooks
+benchmarks
+*.nc

--- a/.syncignore-send
+++ b/.syncignore-send
@@ -1,0 +1,14 @@
+.snakemake
+.git
+.pytest_cache
+.ipynb_checkpoints
+.vscode
+.DS_Store
+__pycache__
+*.pyc
+*.pyo
+*.ipynb
+notebooks
+benchmarks
+resources
+results


### PR DESCRIPTION
I am increasingly using `rsync` to keep my local developments in sync with the cluster version.

The key here to make it effective is to select files that are ignored from being synced (where one can distinguish send/receive):

```
rsync -uva --no-g --chmod=Dg+s --exclude-from=.syncignore-send --rsh="ssh -c aes128-gcm@openssh.com -p 22" . <user>@<remote_url>:<remote_folder>/pypsa-eur-sec
```

See euro-calliope for a reference: https://github.com/calliope-project/euro-calliope/blob/develop/.syncignore-send