### PR TITLE
copy pypsa-eur config.yaml into results folder

### DIFF
--- a/scripts/copy_config.py
+++ b/scripts/copy_config.py
@@ -5,7 +5,8 @@ files = [
     "config.yaml",
     "Snakefile",
     "scripts/solve_network.py",
-    "scripts/prepare_sector_network.py"
+    "scripts/prepare_sector_network.py",
+    "../pypsa-eur/config.yaml"
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
It makes sense to also copy the `config.yaml` from the PyPSA-Eur subworkflow into the `results/your-run-name/configs` folder.