### PR TITLE
Remove non-ascii character from source file

### DIFF
--- a/scripts/build_industry_sector_ratios.py
+++ b/scripts/build_industry_sector_ratios.py
@@ -1006,7 +1006,7 @@ def non_ferrous_metals():
     # Alumina
 
     # High enthalpy heat is converted to methane.
-    # Process heat at T>500ºC is required here.
+    # Process heat at T>500C is required here.
     # Refining is electrified.
     # There are no process emissions associated to Alumina manufacturing.
 


### PR DESCRIPTION
Unfortunately Snakemake for now reads files using the default OS file encoding, which may not be UTF-8. Therefore, it is best to be conservative and only use ascii in source files for now.

This actually crashed the pypsa-eur-sec snakemake workflow for me on a server where the file in question was attempted decoded in ascii.

This fix will be redundant once https://github.com/snakemake/snakemake/pull/1146 gets merged, but it may still be a little while until that filters down to everyone.