### PR TITLE
Create config file from default if not found

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,12 @@
 
+from os.path import exists
+from shutil import copyfile
+
 from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 HTTP = HTTPRemoteProvider()
+
+if not exists("config.yaml"):
+    copyfile("config.default.yaml", "config.yaml")
 
 configfile: "config.yaml"
 


### PR DESCRIPTION
Similarly to pypsa-eur, if the config file is not found, we can create it as a copy of `config.default.yaml`. 

The rationale, just as with pypsa-eur, is that makes it easier to include pypsa-eur-sec as a subworkflow in a snakemake workflow. (See https://github.com/PyPSA/pypsa-eur/pull/105.) It's not strictly speaking necessary, but certainly nice to have when using pypsa-eur-sec as a subworkflow.