### PR TITLE
fix for GlobalConstraints mu with "co2_sequestration_limit"

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -351,6 +351,15 @@ solving:
     track_iterations: false
     min_iterations: 4
     max_iterations: 6
+    keep_shadowprices:
+      - Bus
+      - Line
+      - Link
+      - Transformer
+      - GlobalConstraint
+      - Generator
+      - Store
+      - StorageUnit
 
   solver:
     name: gurobi

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -54,9 +54,16 @@ incorporates retrofitting options to hydrogen.
   transmission routes. Previously, only the electricity transmission routes were
   considered.
 
+**New features and functionality**
+
 * Option ``retrieve_sector_databundle`` to automatically retrieve and extract data bundle.
 
 * Add regionalised hydrogen salt cavern storage potentials from `Technical Potential of Salt Caverns for Hydrogen Storage in Europe <https://doi.org/10.20944/preprints201910.0187.v1>`_.
+
+**Bugfixes**
+
+* The CO2 sequestration limit implemented as GlobalConstraint (introduced in the previous version)
+  caused a failure to read in the shadow prices of other global constraints.
 
 
 PyPSA-Eur-Sec 0.6.0 (4 October 2021)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -223,7 +223,12 @@ def add_co2_sequestration_limit(n, sns):
     rhs = n.config["sector"].get("co2_sequestration_potential", 200) * 1e6
     
     name = 'co2_sequestration_limit'
-    define_constraints(n, lhs, "<=", rhs, 'GlobalConstraint',
+    sense = "<="
+
+    n.add("GlobalConstraint", name, sense=sense, constant=rhs,
+          type=np.nan, carrier_attribute=np.nan)
+
+    define_constraints(n, lhs, sense, rhs, 'GlobalConstraint',
                        'mu', axes=pd.Index([name]), spec=name)
 
 
@@ -240,6 +245,7 @@ def solve_network(n, config, opts='', **kwargs):
     track_iterations = cf_solving.get('track_iterations', False)
     min_iterations = cf_solving.get('min_iterations', 4)
     max_iterations = cf_solving.get('max_iterations', 6)
+    keep_shadowprices = cf_solving.get('keep_shadowprices', True)
 
     # add to network for extra_functionality
     n.config = config
@@ -247,13 +253,16 @@ def solve_network(n, config, opts='', **kwargs):
 
     if cf_solving.get('skip_iterations', False):
         network_lopf(n, solver_name=solver_name, solver_options=solver_options,
-                     extra_functionality=extra_functionality, **kwargs)
+                     extra_functionality=extra_functionality, 
+                     keep_shadowprices=keep_shadowprices, **kwargs)
     else:
         ilopf(n, solver_name=solver_name, solver_options=solver_options,
               track_iterations=track_iterations,
               min_iterations=min_iterations,
               max_iterations=max_iterations,
-              extra_functionality=extra_functionality, **kwargs)
+              extra_functionality=extra_functionality,
+              keep_shadowprices=keep_shadowprices,
+              **kwargs)
     return n
 
 


### PR DESCRIPTION
With the "co2_sequestration_limit" implemented as `extra_functionality`, the duals of the GlobalConstraints were not placed in the 'mu' column (duals for co2 limit and line volume limit were no longer available).

This fixes this behaviour and also adds the "co2_sequestration_limit" to the GlobalConstraints dataframe.

Additionally, added configuration options to handle for which components to keep the shadowprices.