### PR TITLE
Myopic fix

### DIFF
--- a/data/override_component_attrs/generators.csv
+++ b/data/override_component_attrs/generators.csv
@@ -1,3 +1,4 @@
 attribute,type,unit,default,description,status
-build_year,integer,year,n/a,build year,Input (optional)
-lifetime,float,years,n/a,lifetime,Input (optional) 
+carrier,string,n/a,n/a,carrier,Input (optional)
+lifetime,float,years,inf,lifetime,Input (optional)
+build_year,int,year ,0,build year,Input (optional)

--- a/data/override_component_attrs/links.csv
+++ b/data/override_component_attrs/links.csv
@@ -2,12 +2,12 @@ attribute,type,unit,default,description,status
 bus2,string,n/a,n/a,2nd bus,Input (optional)
 bus3,string,n/a,n/a,3rd bus,Input (optional)
 bus4,string,n/a,n/a,4th bus,Input (optional)
-efficiency2,static or series,per unit,1.,2nd bus efficiency,Input (optional)
-efficiency3,static or series,per unit,1.,3rd bus efficiency,Input (optional)
-efficiency4,static or series,per unit,1.,4th bus efficiency,Input (optional)
-p2,series,MW,0.,2nd bus output,Output
-p3,series,MW,0.,3rd bus output,Output
-p4,series,MW,0.,4th bus output,Output
-build_year,integer,year,n/a,build year,Input (optional)
-lifetime,float,years,n/a,lifetime,Input (optional)
+efficiency2,static or series,per unit,1,2nd bus efficiency,Input (optional)
+efficiency3,static or series,per unit,1,3rd bus efficiency,Input (optional)
+efficiency4,static or series,per unit,1,4th bus efficiency,Input (optional)
+p2,series,MW,0,2nd bus output,Output
+p3,series,MW,0,3rd bus output,Output
+p4,series,MW,0,4th bus output,Output
 carrier,string,n/a,n/a,carrier,Input (optional)
+lifetime,float,years,inf,lifetime,Input (optional)
+build_year,int,year ,0,build year,Input (optional)

--- a/data/override_component_attrs/stores.csv
+++ b/data/override_component_attrs/stores.csv
@@ -1,4 +1,4 @@
 attribute,type,unit,default,description,status
-build_year,integer,year,n/a,build year,Input (optional)
-lifetime,float,years,n/a,lifetime,Input (optional)
 carrier,string,n/a,n/a,carrier,Input (optional)
+lifetime,float,years,inf,lifetime,Input (optional)
+build_year,int,year ,0,build year,Input (optional)

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from add_existing_baseyear import add_build_year_to_new_assets
 from helper import override_component_attrs
+from solve_network import basename
 
 
 def add_brownfield(n, n_p, year):
@@ -79,8 +80,23 @@ def add_brownfield(n, n_p, year):
         # deal with gas network
         pipe_carrier = ['gas pipeline']
         if snakemake.config["sector"]['H2_retrofit']:
+            # drop capacities of previous year to avoid duplicating
             to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year!=year)
             n.mremove("Link", n.links.loc[to_drop].index)
+
+            # subtract the already retrofitted from today's gas grid capacity
+            h2_retrofitted_fixed_i = n.links[(n.links.carrier=='H2 pipeline retrofitted') & (n.links.build_year!=year)].index
+            gas_pipes_i =  n.links[n.links.carrier.isin(pipe_carrier)].index
+            CH4_per_H2 = 1 / snakemake.config["sector"]["H2_retrofit_capacity_per_CH4"]
+            fr = "H2 pipeline retrofitted"
+            to = "gas pipeline"
+            # today's pipe capacity
+            pipe_capacity = n.links.loc[gas_pipes_i, 'p_nom']
+            # already retrofitted capacity from gas -> H2
+            already_retrofitted = (n.links.loc[h2_retrofitted_fixed_i, 'p_nom']
+                                   .rename(lambda x: basename(x).replace(fr, to)).groupby(level=0).sum())
+            remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(index=pipe_capacity.index).fillna(0)
+            n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
         else:
             new_pipes = n.links.carrier.isin(pipe_carrier) & (n.links.build_year==year)
             n.links.loc[new_pipes, "p_nom"] = 0.

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -8,6 +8,7 @@ idx = pd.IndexSlice
 
 import pypsa
 import yaml
+import numpy as np
 
 from add_existing_baseyear import add_build_year_to_new_assets
 from helper import override_component_attrs
@@ -25,7 +26,7 @@ def add_brownfield(n, n_p, year):
         # CO2 or global EU values since these are already in n
         n_p.mremove(
             c.name,
-            c.df.index[c.df.lifetime.isna()]
+            c.df.index[c.df.lifetime==np.inf]
         )
 
         # remove assets whose build_year + lifetime < year
@@ -44,7 +45,7 @@ def add_brownfield(n, n_p, year):
         )]
 
         threshold = snakemake.config['existing_capacities']['threshold_capacity']
-        
+
         if not chp_heat.empty:
             threshold_chp_heat = (threshold
                 * c.df.efficiency[chp_heat.str.replace("heat", "electric")].values
@@ -55,7 +56,7 @@ def add_brownfield(n, n_p, year):
                 c.name,
                 chp_heat[c.df.loc[chp_heat, attr + "_nom_opt"] < threshold_chp_heat]
             )
-        
+
         n_p.mremove(
             c.name,
             c.df.index[c.df[attr + "_nom_extendable"] & ~c.df.index.isin(chp_heat) & (c.df[attr + "_nom_opt"] < threshold)]

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -83,9 +83,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             'add_brownfield',
             simpl='',
-            clusters=48,
+            clusters="45",
+            opts="",
             lv=1.0,
-            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            sector_opts='Co2L0-168H-T-H-B-I-A-solar3-dist1',
             planning_horizons=2030,
         )
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -88,10 +88,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             'add_brownfield',
             simpl='',
-            clusters="45",
+            clusters="37",
             opts="",
             lv=1.0,
-            sector_opts='168H-T-H-B-I-A-solar+p3-dist1',
+            sector_opts='168H-T-H-B-I-solar+p3-dist1',
             planning_horizons=2030,
         )
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -19,6 +19,11 @@ def add_brownfield(n, n_p, year):
 
     print("adding brownfield")
 
+    # electric transmission grid set optimised capacities of previous as minimum
+    n.lines.s_nom_min = n_p.lines.s_nom_opt
+    dc_i = n.links[n.links.carrier=="DC"].index
+    n.links.loc[dc_i, "p_nom_min"] = n_p.links.loc[dc_i, "p_nom_opt"]
+
     for c in n_p.iterate_components(["Link", "Generator", "Store"]):
 
         attr = "e" if c.name == "Store" else "p"
@@ -101,6 +106,7 @@ def add_brownfield(n, n_p, year):
             new_pipes = n.links.carrier.isin(pipe_carrier) & (n.links.build_year==year)
             n.links.loc[new_pipes, "p_nom"] = 0.
             n.links.loc[new_pipes, "p_nom_min"] = 0.
+
 
 
 #%%

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -76,7 +76,12 @@ def add_brownfield(n, n_p, year):
         for tattr in n.component_attrs[c.name].index[selection]:
             n.import_series_from_dataframe(c.pnl[tattr], c.name, tattr)
 
+        # deal with gas network
+        pipe_carrier = ['gas pipeline']
+        to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year!=year)
+        n.mremove("Link", n.links.loc[to_drop].index)
 
+#%%
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
@@ -86,7 +91,7 @@ if __name__ == "__main__":
             clusters="45",
             opts="",
             lv=1.0,
-            sector_opts='Co2L0-168H-T-H-B-I-A-solar3-dist1',
+            sector_opts='168H-T-H-B-I-A-solar+p3-dist1',
             planning_horizons=2030,
         )
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -78,8 +78,14 @@ def add_brownfield(n, n_p, year):
 
         # deal with gas network
         pipe_carrier = ['gas pipeline']
-        to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year!=year)
-        n.mremove("Link", n.links.loc[to_drop].index)
+        if snakemake.config["sector"]['H2_retrofit']:
+            to_drop = n.links.carrier.isin(pipe_carrier) & (n.links.build_year!=year)
+            n.mremove("Link", n.links.loc[to_drop].index)
+        else:
+            new_pipes = n.links.carrier.isin(pipe_carrier) & (n.links.build_year==year)
+            n.links.loc[new_pipes, "p_nom"] = 0.
+            n.links.loc[new_pipes, "p_nom_min"] = 0.
+
 
 #%%
 if __name__ == "__main__":

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -409,12 +409,11 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
                 lifetime=costs.at[costs_name, 'lifetime']
             )
 
-            bus0 = vars(spatial)["gas"].nodes
 
             n.madd("Link",
                 nodes[name],
                 suffix= f" {name} gas boiler-{grouping_year}",
-                bus0=bus0,
+                bus0=spatial.gas.nodes,
                 bus1=nodes[name] + " " + name + " heat",
                 bus2="co2 atmosphere",
                 carrier=name + " gas boiler",
@@ -429,7 +428,7 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
             n.madd("Link",
                 nodes[name],
                 suffix=f" {name} oil boiler-{grouping_year}",
-                bus0="EU oil",
+                bus0=spatial.oil.nodes,
                 bus1=nodes[name] + " " + name + " heat",
                 bus2="co2 atmosphere",
                 carrier=name + " oil boiler",
@@ -458,7 +457,7 @@ if __name__ == "__main__":
             clusters="37",
             lv=1.0,
             opts='',
-            sector_opts='Co2L0-168H-T-H-B-I-solar+p3-dist1',
+            sector_opts='168H-T-H-B-I-solar+p3-dist1',
             planning_horizons=2020,
         )
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -450,7 +450,7 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
             threshold = snakemake.config['existing_capacities']['threshold_capacity']
             n.mremove("Link", [index for index in n.links.index.to_list() if str(grouping_year) in index and n.links.p_nom[index] < threshold])
 
-#%%
+
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -28,7 +28,7 @@ def add_build_year_to_new_assets(n, baseyear):
     # Give assets with lifetimes and no build year the build year baseyear
     for c in n.iterate_components(["Link", "Generator", "Store"]):
 
-        assets = c.df.index[~c.df.lifetime.isna() & c.df.build_year==0]
+        assets = c.df.index[(c.df.lifetime!=np.inf) & (c.df.build_year==0)]
         c.df.loc[assets, "build_year"] = baseyear
 
         # add -baseyear to name

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -251,11 +251,15 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
                 )
 
         else:
+            bus0 = n.buses[(n.buses.carrier==carrier[generator])].index
+            if any(n.buses.loc[bus0,"location"]!="EU"):
+                bus0 = n.buses[n.buses.location.isin(capacity.index) &
+                               (n.buses.carrier==carrier[generator])].index
 
             n.madd("Link",
                 capacity.index,
                 suffix= " " + generator +"-" + str(grouping_year),
-                bus0="EU " + carrier[generator],
+                bus0=bus0,
                 bus1=capacity.index,
                 bus2="co2 atmosphere",
                 carrier=generator,
@@ -404,10 +408,15 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
                 lifetime=costs.at[costs_name, 'lifetime']
             )
 
+            bus0 = n.buses[(n.buses.carrier=="gas")].index
+            if any(n.buses.loc[bus0,"location"]!="EU"):
+                bus0 = n.buses[n.buses.location.isin(nodal_df[f'{heat_type} gas boiler'][nodes[name]].index) &
+                                (n.buses.carrier=="gas")].index
+
             n.madd("Link",
                 nodes[name],
                 suffix= f" {name} gas boiler-{grouping_year}",
-                bus0="EU gas",
+                bus0=bus0,
                 bus1=nodes[name] + " " + name + " heat",
                 bus2="co2 atmosphere",
                 carrier=name + " gas boiler",

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -204,7 +204,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
             # to consider electricity grid connection costs or a split between
             # solar utility and rooftop as well, rather take cost assumptions
             # from existing network than from the cost database
-            capital_cost = n.generators[n.generators.carrier==generator+suffix].capital_cost.mean()
+            capital_cost = n.generators.loc[n.generators.carrier==generator+suffix, "capital_cost"].mean()
 
             if 'm' in snakemake.wildcards.clusters:
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -159,7 +159,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
     inv_busmap = {}
     for k, v in busmap.iteritems():
         inv_busmap[v] = inv_busmap.get(v, []) + [k]
-        
+
     clustermaps = busmap_s.map(busmap)
     clustermaps.index = clustermaps.index.astype(int)
 
@@ -197,7 +197,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         capacity = capacity[capacity > snakemake.config['existing_capacities']['threshold_capacity']]
 
         if generator in ['solar', 'onwind', 'offwind']:
-        
+
             suffix = '-ac' if generator == 'offwind' else ''
             name_suffix = f' {generator}{suffix}-{baseyear}'
 
@@ -213,7 +213,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
 
                     p_max_pu = n.generators_t.p_max_pu[[i + name_suffix for i in inv_ind]]
                     p_max_pu.columns=[i + name_suffix for i in inv_ind ]
-                
+
                     n.madd("Generator",
                         [i + name_suffix for i in inv_ind],
                         bus=ind,
@@ -436,17 +436,17 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years
             threshold = snakemake.config['existing_capacities']['threshold_capacity']
             n.mremove("Link", [index for index in n.links.index.to_list() if str(grouping_year) in index and n.links.p_nom[index] < threshold])
 
-
+#%%
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
         snakemake = mock_snakemake(
             'add_existing_baseyear',
             simpl='',
-            clusters=45,
+            clusters="45",
             lv=1.0,
             opts='',
-            sector_opts='Co2L0-168H-T-H-B-I-solar+p3-dist1',
+            sector_opts='168H-T-H-B-I-A-solar+p3-dist1',
             planning_horizons=2020,
         )
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -12,9 +12,11 @@ import xarray as xr
 import pypsa
 import yaml
 
-from prepare_sector_network import prepare_costs
+from prepare_sector_network import prepare_costs, define_spatial
 from helper import override_component_attrs
 
+from types import SimpleNamespace
+spatial = SimpleNamespace()
 
 def add_build_year_to_new_assets(n, baseyear):
     """
@@ -473,7 +475,8 @@ if __name__ == "__main__":
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
-
+    # define spatial resolution of carriers
+    define_spatial(n.buses[n.buses.carrier=="AC"].index, options)
     add_build_year_to_new_assets(n, baseyear)
 
     Nyears = n.snapshot_weightings.generators.sum() / 8760.

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -266,7 +266,7 @@ def plot_h2_map(network):
 
     # make a fake MultiIndex so that area is correct for legend
     bus_sizes.rename(index=lambda x: x.replace(" H2", ""), level=0, inplace=True)
-    # frop all links which are not H2 pipelines
+    # drop all links which are not H2 pipelines
     n.links.drop(n.links.index[~n.links.carrier.str.contains("H2 pipeline")], inplace=True)
 
     h2_new = n.links.loc[n.links.carrier=="H2 pipeline"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1067,14 +1067,14 @@ def add_storage_and_grids(n, costs):
 
     cavern_types = snakemake.config["sector"]["hydrogen_underground_storage_locations"]
     h2_caverns = pd.read_csv(snakemake.input.h2_cavern, index_col=0)
-    
+
     if not h2_caverns.empty and options['hydrogen_underground_storage']:
 
         h2_caverns = h2_caverns[cavern_types].sum(axis=1)
 
         # only use sites with at least 2 TWh potential
         h2_caverns = h2_caverns[h2_caverns > 2]
-        
+
         # convert TWh to MWh
         h2_caverns = h2_caverns * 1e6
 
@@ -1178,9 +1178,9 @@ def add_storage_and_grids(n, costs):
 
         # apply k_edge_augmentation weighted by length of complement edges
         k_edge = options.get("gas_network_connectivity_upgrade", 3)
-        augmentation = k_edge_augmentation(G, k_edge, avail=complement_edges.values)
+        augmentation = list(k_edge_augmentation(G, k_edge, avail=complement_edges.values))
 
-        if list(augmentation):
+        if augmentation:
 
             new_gas_pipes = pd.DataFrame(augmentation, columns=["bus0", "bus1"])
             new_gas_pipes["length"] = new_gas_pipes.apply(haversine, axis=1)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1438,8 +1438,8 @@ def add_land_transport(n, costs):
 
         if "oil" not in n.buses.carrier.unique():
             n.madd("Bus",
-                vars(spatial)["oil"].nodes,
-                location=vars(spatial)["oil"].locations,
+                spatial.oil.nodes,
+                location=spatial.oil.locations,
                 carrier="oil"
             )
 
@@ -1448,7 +1448,7 @@ def add_land_transport(n, costs):
         n.madd("Load",
             nodes,
             suffix=" land transport oil",
-            bus=vars(spatial)["oil"].nodes,
+            bus=spatial.oil.nodes,
             carrier="land transport oil",
             p_set=ice_share / ice_efficiency * transport[nodes]
         )
@@ -2115,7 +2115,7 @@ def add_industry(n, costs):
         n.madd("Load",
             nodes,
             suffix=" shipping oil",
-            bus=vars(spatial)["oil"].nodes,
+            bus=spatial.oil.nodes,
             carrier="shipping oil",
             p_set=p_set
         )
@@ -2131,8 +2131,8 @@ def add_industry(n, costs):
 
     if "oil" not in n.buses.carrier.unique():
         n.madd("Bus",
-            vars(spatial)["oil"].nodes,
-            location=vars(spatial)["oil"].locations,
+            spatial.oil.nodes,
+            location=spatial.oil.locations,
             carrier="oil"
         )
 
@@ -2140,8 +2140,8 @@ def add_industry(n, costs):
 
         #could correct to e.g. 0.001 EUR/kWh * annuity and O&M
         n.madd("Store",
-            [oil_bus + " Store" for oil_bus in vars(spatial)["oil"].nodes],
-            bus=vars(spatial)["oil"].nodes,
+            [oil_bus + " Store" for oil_bus in spatial.oil.nodes],
+            bus=spatial.oil.nodes,
             e_nom_extendable=True,
             e_cyclic=True,
             carrier="oil",
@@ -2150,8 +2150,8 @@ def add_industry(n, costs):
     if "oil" not in n.generators.carrier.unique():
 
         n.madd("Generator",
-            vars(spatial)["oil"].nodes,
-            bus=vars(spatial)["oil"].nodes,
+            spatial.oil.nodes,
+            bus=spatial.oil.nodes,
             p_nom_extendable=True,
             carrier="oil",
             marginal_cost=costs.at["oil", 'fuel']
@@ -2166,7 +2166,7 @@ def add_industry(n, costs):
             n.madd("Link",
                 nodes_heat[name] + f" {name} oil boiler",
                 p_nom_extendable=True,
-                bus0=vars(spatial)["oil"].nodes,
+                bus0=spatial.oil.nodes,
                 bus1=nodes_heat[name] + f" {name}  heat",
                 bus2="co2 atmosphere",
                 carrier=f"{name} oil boiler",
@@ -2179,7 +2179,7 @@ def add_industry(n, costs):
     n.madd("Link",
         nodes + " Fischer-Tropsch",
         bus0=nodes + " H2",
-        bus1=vars(spatial)["oil"].nodes,
+        bus1=spatial.oil.nodes,
         bus2=spatial.co2.nodes,
         carrier="Fischer-Tropsch",
         efficiency=costs.at["Fischer-Tropsch", 'efficiency'],
@@ -2191,7 +2191,7 @@ def add_industry(n, costs):
 
     n.madd("Load",
         ["naphtha for industry"],
-        bus=vars(spatial)["oil"].nodes,
+        bus=spatial.oil.nodes,
         carrier="naphtha for industry",
         p_set=industrial_demand.loc[nodes, "naphtha"].sum() / 8760
     )
@@ -2201,7 +2201,7 @@ def add_industry(n, costs):
 
     n.madd("Load",
         ["kerosene for aviation"],
-        bus=vars(spatial)["oil"].nodes,
+        bus=spatial.oil.nodes,
         carrier="kerosene for aviation",
         p_set=p_set
     )
@@ -2354,7 +2354,7 @@ def add_agriculture(n, costs):
 
         n.add("Load",
             "agriculture machinery oil",
-            bus=vars(spatial)["oil"].nodes,
+            bus=spatial.oil.nodes,
             carrier="agriculture machinery oil",
             p_set=ice_share * machinery_nodal_energy.sum() * 1e6 / 8760
         )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 spatial = SimpleNamespace()
 
 
-def define_spatial(nodes):
+def define_spatial(nodes, options):
     """
     Namespace for spatial
 
@@ -38,7 +38,6 @@ def define_spatial(nodes):
     """
 
     global spatial
-    global options
 
     spatial.nodes = nodes
 
@@ -73,7 +72,7 @@ def define_spatial(nodes):
         spatial.co2.vents = ["co2 vent"]
 
     spatial.co2.df = pd.DataFrame(vars(spatial.co2), index=nodes)
-    
+
     # gas
 
     spatial.gas = SimpleNamespace()
@@ -94,6 +93,26 @@ def define_spatial(nodes):
         spatial.gas.biogas_to_gas = ["EU biogas to gas"]
 
     spatial.gas.df = pd.DataFrame(vars(spatial.gas), index=nodes)
+
+    # oil
+    spatial.oil = SimpleNamespace()
+    spatial.oil.nodes = ["EU oil"]
+    spatial.oil.locations = ["EU"]
+
+    # uranium
+    spatial.uranium = SimpleNamespace()
+    spatial.uranium.nodes = ["EU uranium"]
+    spatial.uranium.locations = ["EU"]
+
+    # coal
+    spatial.coal = SimpleNamespace()
+    spatial.coal.nodes = ["EU coal"]
+    spatial.coal.locations = ["EU"]
+
+    # lignite
+    spatial.lignite = SimpleNamespace()
+    spatial.lignite.nodes = ["EU lignite"]
+    spatial.lignite.locations = ["EU"]
 
 
 from types import SimpleNamespace
@@ -1049,7 +1068,7 @@ def add_storage_and_grids(n, costs):
 
     # only use sites with at least 2 TWh potential
     h2_caverns = h2_caverns[h2_caverns > 2]
-    
+
     # convert TWh to MWh
     h2_caverns = h2_caverns * 1e6
 
@@ -1119,7 +1138,7 @@ def add_storage_and_grids(n, costs):
             carrier="gas pipeline",
             lifetime=costs.at['CH4 (g) pipeline', 'lifetime']
         )
-        
+
         # remove fossil generators where there is neither
         # production, LNG terminal, nor entry-point beyond system scope
 
@@ -2438,7 +2457,7 @@ if __name__ == "__main__":
 
     patch_electricity_network(n)
 
-    define_spatial(pop_layout.index)
+    define_spatial(pop_layout.index, options)
 
     if snakemake.config["foresight"] == 'myopic':
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
         snakemake = mock_snakemake(
-            'solve_network_myopic',
+            'solve_network',
             simpl='',
             opts="",
             clusters="37",

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -189,9 +189,9 @@ def add_chp_constraints(n):
 def add_pipe_retrofit_constraint(n):
     """Add constraint for retrofitting existing CH4 pipelines to H2 pipelines."""
 
-    gas_pipes_i = n.links[n.links.carrier=="gas pipeline"].query("p_nom_extendable").index
-    h2_retrofitted_i = n.links[n.links.carrier=='H2 pipeline retrofitted'].query("p_nom_extendable").index
-    h2_retrofitted_fixed_i = n.links[n.links.carrier=='H2 pipeline retrofitted'].index.difference(h2_retrofitted_i)
+    gas_pipes_i = n.links.query("carrier == 'gas pipeline' and p_nom_extendable").index
+    h2_retrofitted_i = n.links.query("carrier == 'H2 pipeline retrofitted' and p_nom_extendable").index
+    h2_retrofitted_fixed_i = n.links.query("carrier == 'H2 pipeline retrofitted' and not p_nom_extendable").index
 
     if h2_retrofitted_i.empty or gas_pipes_i.empty: return
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -185,6 +185,8 @@ def add_chp_constraints(n):
 
         define_constraints(n, lhs, "<=", 0, 'chplink', 'backpressure')
 
+def basename(x):
+     return x.split("-2")[0]
 
 def add_pipe_retrofit_constraint(n):
     """Add constraint for retrofitting existing CH4 pipelines to H2 pipelines."""
@@ -201,10 +203,9 @@ def add_pipe_retrofit_constraint(n):
     fr = "H2 pipeline retrofitted"
     to = "gas pipeline"
 
-    pipe_capacity = n.links.loc[gas_pipes_i, 'p_nom'].rename(index=lambda x: x.split("-2")[0])
+    pipe_capacity = n.links.loc[gas_pipes_i, 'p_nom'].rename(basename)
     already_retrofitted = (n.links.loc[h2_retrofitted_fixed_i, 'p_nom']
-                           .rename(index= lambda x: x.split("-2")[0]
-                                   .replace(fr, to)).groupby(level=0).sum())
+                           .rename(lambda x: basename(x).replace(fr, to)).groupby(level=0).sum())
     remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(index=pipe_capacity.index).fillna(0)
 
     lhs = linexpr(
@@ -212,7 +213,7 @@ def add_pipe_retrofit_constraint(n):
         (1, link_p_nom.loc[gas_pipes_i])
     )
 
-    lhs.rename(index=lambda x: x.split("-2")[0], inplace=True)
+    lhs.rename(basename, inplace=True)
     define_constraints(n, lhs, "=", remaining_capacity, 'Link', 'pipe_retrofit')
 
 
@@ -284,7 +285,7 @@ if __name__ == "__main__":
             'solve_network_myopic',
             simpl='',
             opts="",
-            clusters="45",
+            clusters="37",
             lv=1.0,
             sector_opts='168H-T-H-B-I-A-solar+p3-dist1',
             planning_horizons="2030",

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -33,14 +33,14 @@ def _add_land_use_constraint(n):
         existing = n.generators.loc[n.generators.carrier==carrier,"p_nom"].groupby(n.generators.bus.map(n.buses.location)).sum()
         existing.index += " " + carrier + "-" + snakemake.wildcards.planning_horizons
         n.generators.loc[existing.index,"p_nom_max"] -= existing
-    
+
     n.generators.p_nom_max.clip(lower=0, inplace=True)
 
 
 def _add_land_use_constraint_m(n):
     # if generators clustering is lower than network clustering, land_use accounting is at generators clusters
 
-    planning_horizons = snakemake.config["scenario"]["planning_horizons"] 
+    planning_horizons = snakemake.config["scenario"]["planning_horizons"]
     grouping_years = snakemake.config["existing_capacities"]["grouping_years"]
     current_horizon = snakemake.wildcards.planning_horizons
 
@@ -48,9 +48,9 @@ def _add_land_use_constraint_m(n):
 
         existing = n.generators.loc[n.generators.carrier==carrier,"p_nom"]
         ind = list(set([i.split(sep=" ")[0] + ' ' + i.split(sep=" ")[1] for i in existing.index]))
-        
+
         previous_years = [
-            str(y) for y in 
+            str(y) for y in
             planning_horizons + grouping_years
             if y < int(snakemake.wildcards.planning_horizons)
         ]
@@ -59,13 +59,13 @@ def _add_land_use_constraint_m(n):
             ind2 = [i for i in ind if i + " " + carrier + "-" + p_year in existing.index]
             sel_current = [i + " " + carrier + "-" + current_horizon for i in ind2]
             sel_p_year = [i + " " + carrier + "-" + p_year for i in ind2]
-            n.generators.loc[sel_current, "p_nom_max"] -= existing.loc[sel_p_year].rename(lambda x: x[:-4] + current_horizon) 
-    
+            n.generators.loc[sel_current, "p_nom_max"] -= existing.loc[sel_p_year].rename(lambda x: x[:-4] + current_horizon)
+
     n.generators.p_nom_max.clip(lower=0, inplace=True)
 
 
 def prepare_network(n, solve_opts=None):
-    
+
     if 'clip_p_max_pu' in solve_opts:
         for df in (n.generators_t.p_max_pu, n.generators_t.p_min_pu, n.storage_units_t.inflow):
             df.where(df>solve_opts['clip_p_max_pu'], other=0., inplace=True)
@@ -189,36 +189,42 @@ def add_chp_constraints(n):
 def add_pipe_retrofit_constraint(n):
     """Add constraint for retrofitting existing CH4 pipelines to H2 pipelines."""
 
-    gas_pipes_i = n.links[n.links.carrier=="gas pipeline"].index
-    h2_retrofitted_i = n.links[n.links.carrier=='H2 pipeline retrofitted'].index
+    gas_pipes_i = n.links[n.links.carrier=="gas pipeline"].query("p_nom_extendable").index
+    h2_retrofitted_i = n.links[n.links.carrier=='H2 pipeline retrofitted'].query("p_nom_extendable").index
+    h2_retrofitted_fixed_i = n.links[n.links.carrier=='H2 pipeline retrofitted'].index.difference(h2_retrofitted_i)
 
     if h2_retrofitted_i.empty or gas_pipes_i.empty: return
 
     link_p_nom = get_var(n, "Link", "p_nom")
 
-    pipe_capacity = n.links.loc[gas_pipes_i, 'p_nom']
-
     CH4_per_H2 = 1 / n.config["sector"]["H2_retrofit_capacity_per_CH4"]
-
     fr = "H2 pipeline retrofitted"
     to = "gas pipeline"
+
+    pipe_capacity = n.links.loc[gas_pipes_i, 'p_nom'].rename(index=lambda x: x.split("-2")[0])
+    already_retrofitted = (n.links.loc[h2_retrofitted_fixed_i, 'p_nom']
+                           .rename(index= lambda x: x.split("-2")[0]
+                                   .replace(fr, to)).groupby(level=0).sum())
+    remaining_capacity = pipe_capacity - CH4_per_H2 * already_retrofitted.reindex(index=pipe_capacity.index).fillna(0)
+
     lhs = linexpr(
         (CH4_per_H2, link_p_nom.loc[h2_retrofitted_i].rename(index=lambda x: x.replace(fr, to))),
         (1, link_p_nom.loc[gas_pipes_i])
     )
 
-    define_constraints(n, lhs, "=", pipe_capacity, 'Link', 'pipe_retrofit')
+    lhs.rename(index=lambda x: x.split("-2")[0], inplace=True)
+    define_constraints(n, lhs, "=", remaining_capacity, 'Link', 'pipe_retrofit')
 
 
 def add_co2_sequestration_limit(n, sns):
-    
+
     co2_stores = n.stores.loc[n.stores.carrier=='co2 stored'].index
 
     if co2_stores.empty or ('Store', 'e') not in n.variables.index:
         return
-    
+
     vars_final_co2_stored = get_var(n, 'Store', 'e').loc[sns[-1], co2_stores]
-    
+
     lhs = linexpr((1, vars_final_co2_stored)).sum()
 
     limit = n.config["sector"].get("co2_sequestration_potential", 200) * 1e6
@@ -226,7 +232,7 @@ def add_co2_sequestration_limit(n, sns):
         if not "seq" in o: continue
         limit = float(o[o.find("seq")+3:])
         break
-    
+
     name = 'co2_sequestration_limit'
     sense = "<="
 
@@ -258,7 +264,7 @@ def solve_network(n, config, opts='', **kwargs):
 
     if cf_solving.get('skip_iterations', False):
         network_lopf(n, solver_name=solver_name, solver_options=solver_options,
-                     extra_functionality=extra_functionality, 
+                     extra_functionality=extra_functionality,
                      keep_shadowprices=keep_shadowprices, **kwargs)
     else:
         ilopf(n, solver_name=solver_name, solver_options=solver_options,
@@ -275,12 +281,13 @@ if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
         snakemake = mock_snakemake(
-            'solve_network',
+            'solve_network_myopic',
             simpl='',
-            clusters=48,
+            opts="",
+            clusters="45",
             lv=1.0,
-            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-            planning_horizons=2050,
+            sector_opts='168H-T-H-B-I-A-solar+p3-dist1',
+            planning_horizons="2030",
         )
 
     logging.basicConfig(filename=snakemake.log.python,


### PR DESCRIPTION
this PR should resolve some conflicts with the latest changes if running the model with myopic foresight, namely:

- adjust functions to work with the new default lifetime np.inf (instead of previous NaN)
- add electricity grid connection costs to renewables solar and onwind, take the right capital costs if solar is splited into rooftop and utility
- general update of the mocksnakemake for testing
- use the `define_spatial` function also for other conventional carriers
- add lifetime for H2 Stores
- enable to run the myopic code with a spatial resolved gas network, which means:
  - adding existing components to the right buses ("EU gas" or all buses with carrier gas)
  - avoid doubling of the existing gas network in module add_brownfield
  - adjusting the retrofitting pipe line constraint to work with multiple build years of the pipe
  - adjusting the plot_h2 function to work with multiple build years of the pipe lines


