### PR TITLE
Parameter space file

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -11,6 +11,13 @@ run: your-run-name  # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "planning_horizons" below
 
+# Scenario options can either be specified here in the config file or by using a parameterspace .csv file
+# If scenario options are specified using the config file comment out the parameterspace option
+# If scenario options are specified using the parameterspace .csv file specify the path in the 
+# parameterspace option. 
+# When using the paramterspace option all scenario options from the config file are overwritten. 
+
+#parameterspace: params.csv # Path to parameterspace .csv 
 scenario:
   simpl: # only relevant for PyPSA-Eur
     - ''

--- a/params.csv
+++ b/params.csv
@@ -1,0 +1,4 @@
+simpl,lv,clusters,opts,sector_opts,planning_horizons
+,1.1,37,,Co2L0-168H-T-H-B-I-A-solar+p3-dist1,2030
+,1.2,45,,,
+,1.3,,,,

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -288,6 +288,7 @@ if __name__ == "__main__":
 
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:
+        from pathlib import Path
         Path(tmpdir).mkdir(parents=True, exist_ok=True)
     opts = snakemake.wildcards.opts.split('-')
     solve_opts = snakemake.config['solving']['options']

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -288,7 +288,6 @@ if __name__ == "__main__":
 
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:
-        from pathlib import Path
         Path(tmpdir).mkdir(parents=True, exist_ok=True)
     opts = snakemake.wildcards.opts.split('-')
     solve_opts = snakemake.config['solving']['options']


### PR DESCRIPTION
Allows the use of a parameter space file to define the config.scenarios options, as sugested in #210. The original use of defining the options using the config file is maintained when the parameterspace options is out commented in the config file. 