### PR TITLE
Weather year and investment years as wildcards (PyPSA-Eur-Sec)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ config.yaml
 doc/_build
 
 *.xls
+cluster.yaml
+snakemake_cluster

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ doc/_build
 *.xls
 cluster.yaml
 snakemake_cluster
+data/pypsa-eur-sec-data-bundle.tar.gz
+data/md5sums.txt
+data/h2_salt_caverns_GWh_per_sqkm.geojson

--- a/Snakefile
+++ b/Snakefile
@@ -12,6 +12,7 @@ configfile: "config.yaml"
 
 
 wildcard_constraints:
+    weatheryear="[0-9]*",
     lv="[a-z0-9\.]+",
     simpl="[a-zA-Z0-9]*",
     clusters="[0-9]+m?",
@@ -35,13 +36,13 @@ rule all:
 
 rule solve_all_networks:
     input:
-        expand(RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        expand(RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
                **config['scenario'])
 
 
 rule prepare_sector_networks:
     input:
-        expand(RDIR + "/prenetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        expand(RDIR + "/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
                **config['scenario'])
 
 datafiles = [
@@ -80,9 +81,9 @@ rule build_clustered_population_layouts:
         pop_layout_total="resources/pop_layout_total.nc",
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur('resources/regions_onshore_elec_s{simpl}_{clusters}.geojson')
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson')
     output:
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv"
+        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv"
     resources: mem_mb=10000
     benchmark: "benchmarks/build_clustered_population_layouts/s{simpl}_{clusters}"
     script: "scripts/build_clustered_population_layouts.py"
@@ -93,9 +94,9 @@ rule build_simplified_population_layouts:
         pop_layout_total="resources/pop_layout_total.nc",
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur('resources/regions_onshore_elec_s{simpl}.geojson')
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}.geojson')
     output:
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}.csv"
+        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}.csv"
     resources: mem_mb=10000
     benchmark: "benchmarks/build_clustered_population_layouts/s{simpl}"
     script: "scripts/build_clustered_population_layouts.py"
@@ -131,8 +132,8 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             entry="data/gas_network/scigrid-gas/data/IGGIELGN_BorderPoints.geojson",
             production="data/gas_network/scigrid-gas/data/IGGIELGN_Productions.geojson",
             planned_lng="data/gas_network/planned_LNGs.csv",
-            regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"),
-            regions_offshore=pypsaeur('resources/regions_offshore_elec_s{simpl}_{clusters}.geojson')
+            regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
+            regions_offshore=pypsaeur('resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson')
         output:
             gas_input_nodes="resources/gas_input_locations_s{simpl}_{clusters}.geojson",
             gas_input_nodes_simplified="resources/gas_input_locations_s{simpl}_{clusters}_simplified.csv"
@@ -143,10 +144,10 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
     rule cluster_gas_network:
         input:
             cleaned_gas_network="resources/gas_network.csv",
-            regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"),
-            regions_offshore=pypsaeur("resources/regions_offshore_elec_s{simpl}_{clusters}.geojson")
+            regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
+            regions_offshore=pypsaeur("resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
         output:
-            clustered_gas_network="resources/gas_network_elec_s{simpl}_{clusters}.csv"
+            clustered_gas_network="resources/gas_network_elec{weatheryear}_s{simpl}_{clusters}.csv"
         resources: mem_mb=4000
         script: "scripts/cluster_gas_network.py"
 
@@ -161,11 +162,11 @@ rule build_heat_demands:
         pop_layout_total="resources/pop_layout_total.nc",
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson")
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
     output:
-        heat_demand_urban="resources/heat_demand_urban_elec_s{simpl}_{clusters}.nc",
-        heat_demand_rural="resources/heat_demand_rural_elec_s{simpl}_{clusters}.nc",
-        heat_demand_total="resources/heat_demand_total_elec_s{simpl}_{clusters}.nc"
+        heat_demand_urban="resources/heat_demand_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        heat_demand_rural="resources/heat_demand_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        heat_demand_total="resources/heat_demand_total_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
     benchmark: "benchmarks/build_heat_demands/s{simpl}_{clusters}"
     script: "scripts/build_heat_demand.py"
@@ -176,14 +177,14 @@ rule build_temperature_profiles:
         pop_layout_total="resources/pop_layout_total.nc",
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson")
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
     output:
-        temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc"
+        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
     benchmark: "benchmarks/build_temperature_profiles/s{simpl}_{clusters}"
     script: "scripts/build_temperature_profiles.py"
@@ -191,19 +192,19 @@ rule build_temperature_profiles:
 
 rule build_cop_profiles:
     input:
-        temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc"
+        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
     output:
-        cop_soil_total="resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-        cop_soil_rural="resources/cop_soil_rural_elec_s{simpl}_{clusters}.nc",
-        cop_soil_urban="resources/cop_soil_urban_elec_s{simpl}_{clusters}.nc",
-        cop_air_total="resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
-        cop_air_rural="resources/cop_air_rural_elec_s{simpl}_{clusters}.nc",
-        cop_air_urban="resources/cop_air_urban_elec_s{simpl}_{clusters}.nc"
+        cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_soil_rural="resources/cop_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_soil_urban="resources/cop_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_rural="resources/cop_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_urban="resources/cop_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
     benchmark: "benchmarks/build_cop_profiles/s{simpl}_{clusters}"
     script: "scripts/build_cop_profiles.py"
@@ -214,11 +215,11 @@ rule build_solar_thermal_profiles:
         pop_layout_total="resources/pop_layout_total.nc",
         pop_layout_urban="resources/pop_layout_urban.nc",
         pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson")
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
     output:
-        solar_thermal_total="resources/solar_thermal_total_elec_s{simpl}_{clusters}.nc",
-        solar_thermal_urban="resources/solar_thermal_urban_elec_s{simpl}_{clusters}.nc",
-        solar_thermal_rural="resources/solar_thermal_rural_elec_s{simpl}_{clusters}.nc"
+        solar_thermal_total="resources/solar_thermal_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        solar_thermal_urban="resources/solar_thermal_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        solar_thermal_rural="resources/solar_thermal_rural_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
     benchmark: "benchmarks/build_solar_thermal_profiles/s{simpl}_{clusters}"
     script: "scripts/build_solar_thermal_profiles.py"
@@ -251,7 +252,7 @@ rule build_biomass_potentials:
     input:
         enspreso_biomass=HTTP.remote("https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx", keep_local=True),
         nuts2="data/nuts/NUTS_RG_10M_2013_4326_LEVL_2.geojson", # https://gisco-services.ec.europa.eu/distribution/v2/nuts/download/#nuts21
-        regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"),
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
         nuts3_population="../pypsa-eur/data/bundle/nama_10r_3popgdp.tsv.gz",
         swiss_cantons="../pypsa-eur/data/bundle/ch_cantons.csv",
         swiss_population="../pypsa-eur/data/bundle/je-e-21.03.02.xls",
@@ -283,8 +284,8 @@ else:
 rule build_salt_cavern_potentials:
     input:
         salt_caverns="data/h2_salt_caverns_GWh_per_sqkm.geojson",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec_s{simpl}_{clusters}.geojson"),
-        regions_offshore=pypsaeur("resources/regions_offshore_elec_s{simpl}_{clusters}.geojson"),
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
+        regions_offshore=pypsaeur("resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
     output:
         h2_cavern_potential="resources/salt_cavern_potentials_s{simpl}_{clusters}.csv"
     threads: 1
@@ -342,11 +343,11 @@ rule build_industrial_production_per_country_tomorrow:
 
 rule build_industrial_distribution_key:
     input:
-        regions_onshore=pypsaeur('resources/regions_onshore_elec_s{simpl}_{clusters}.geojson'),
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson'),
+        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
         hotmaps_industrial_database="data/Industrial_Database.csv",
     output:
-        industrial_distribution_key="resources/industrial_distribution_key_elec_s{simpl}_{clusters}.csv"
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
     benchmark: "benchmarks/build_industrial_distribution_key/s{simpl}_{clusters}"
@@ -355,10 +356,10 @@ rule build_industrial_distribution_key:
 
 rule build_industrial_production_per_node:
     input:
-        industrial_distribution_key="resources/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv",
         industrial_production_per_country_tomorrow="resources/industrial_production_per_country_tomorrow_{planning_horizons}.csv"
     output:
-        industrial_production_per_node="resources/industrial_production_elec_s{simpl}_{clusters}_{planning_horizons}.csv"
+        industrial_production_per_node="resources/industrial_production_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
     benchmark: "benchmarks/build_industrial_production_per_node/s{simpl}_{clusters}_{planning_horizons}"
@@ -368,10 +369,10 @@ rule build_industrial_production_per_node:
 rule build_industrial_energy_demand_per_node:
     input:
         industry_sector_ratios="resources/industry_sector_ratios.csv",
-        industrial_production_per_node="resources/industrial_production_elec_s{simpl}_{clusters}_{planning_horizons}.csv",
-        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec_s{simpl}_{clusters}.csv"
+        industrial_production_per_node="resources/industrial_production_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv",
+        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weatheryear}_s{simpl}_{clusters}.csv"
     output:
-        industrial_energy_demand_per_node="resources/industrial_energy_demand_elec_s{simpl}_{clusters}_{planning_horizons}.csv"
+        industrial_energy_demand_per_node="resources/industrial_energy_demand_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
     benchmark: "benchmarks/build_industrial_energy_demand_per_node/s{simpl}_{clusters}_{planning_horizons}"
@@ -393,10 +394,10 @@ rule build_industrial_energy_demand_per_country_today:
 
 rule build_industrial_energy_demand_per_node_today:
     input:
-        industrial_distribution_key="resources/industrial_distribution_key_elec_s{simpl}_{clusters}.csv",
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv",
         industrial_energy_demand_per_country_today="resources/industrial_energy_demand_per_country_today.csv"
     output:
-        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec_s{simpl}_{clusters}.csv"
+        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weatheryear}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
     benchmark: "benchmarks/build_industrial_energy_demand_per_node_today/s{simpl}_{clusters}"
@@ -408,17 +409,17 @@ if config["sector"]["retrofitting"]["retro_endogen"]:
         input:
             building_stock="data/retro/data_building_stock.csv",
             data_tabula="data/retro/tabula-calculator-calcsetbuilding.csv",
-            air_temperature = "resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
+            air_temperature = "resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
             u_values_PL="data/retro/u_values_poland.csv",
             tax_w="data/retro/electricity_taxes_eu.csv",
             construction_index="data/retro/comparative_level_investment.csv",
             floor_area_missing="data/retro/floor_area_missing.csv",
-            clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
+            clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
             cost_germany="data/retro/retro_cost_germany.csv",
             window_assumptions="data/retro/window_assumptions.csv",
         output:
-            retro_cost="resources/retro_cost_elec_s{simpl}_{clusters}.csv",
-            floor_area="resources/floor_area_elec_s{simpl}_{clusters}.csv"
+            retro_cost="resources/retro_cost_elec{weatheryear}_s{simpl}_{clusters}.csv",
+            floor_area="resources/floor_area_elec{weatheryear}_s{simpl}_{clusters}.csv"
         resources: mem_mb=1000
         benchmark: "benchmarks/build_retro_cost/s{simpl}_{clusters}"
         script: "scripts/build_retro_cost.py"
@@ -430,7 +431,7 @@ else:
 rule prepare_sector_network:
     input:
         overrides="data/override_component_attrs",
-        network=pypsaeur('networks/elec_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
+        network=pypsaeur('networks/elec{weatheryear}_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
         energy_totals_name='resources/energy_totals.csv',
         co2_totals_name='resources/co2_totals.csv',
         transport_name='resources/transport_data.csv',
@@ -442,49 +443,49 @@ rule prepare_sector_network:
         profile_offwind_ac=pypsaeur("resources/profile_offwind-ac.nc"),
         profile_offwind_dc=pypsaeur("resources/profile_offwind-dc.nc"),
         h2_cavern="resources/salt_cavern_potentials_s{simpl}_{clusters}.csv",
-        busmap_s=pypsaeur("resources/busmap_elec_s{simpl}.csv"),
-        busmap=pypsaeur("resources/busmap_elec_s{simpl}_{clusters}.csv"),
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
-        simplified_pop_layout="resources/pop_layout_elec_s{simpl}.csv",
-        industrial_demand="resources/industrial_energy_demand_elec_s{simpl}_{clusters}_{planning_horizons}.csv",
-        heat_demand_urban="resources/heat_demand_urban_elec_s{simpl}_{clusters}.nc",
-        heat_demand_rural="resources/heat_demand_rural_elec_s{simpl}_{clusters}.nc",
-        heat_demand_total="resources/heat_demand_total_elec_s{simpl}_{clusters}.nc",
-        temp_soil_total="resources/temp_soil_total_elec_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec_s{simpl}_{clusters}.nc",
-        cop_soil_total="resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-        cop_soil_rural="resources/cop_soil_rural_elec_s{simpl}_{clusters}.nc",
-        cop_soil_urban="resources/cop_soil_urban_elec_s{simpl}_{clusters}.nc",
-        cop_air_total="resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
-        cop_air_rural="resources/cop_air_rural_elec_s{simpl}_{clusters}.nc",
-        cop_air_urban="resources/cop_air_urban_elec_s{simpl}_{clusters}.nc",
-        solar_thermal_total="resources/solar_thermal_total_elec_s{simpl}_{clusters}.nc",
-        solar_thermal_urban="resources/solar_thermal_urban_elec_s{simpl}_{clusters}.nc",
-        solar_thermal_rural="resources/solar_thermal_rural_elec_s{simpl}_{clusters}.nc",
+        busmap_s=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}.csv"),
+        busmap=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}_{clusters}.csv"),
+        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
+        simplified_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}.csv",
+        industrial_demand="resources/industrial_energy_demand_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv",
+        heat_demand_urban="resources/heat_demand_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        heat_demand_rural="resources/heat_demand_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        heat_demand_total="resources/heat_demand_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_soil_rural="resources/cop_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_soil_urban="resources/cop_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_rural="resources/cop_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        cop_air_urban="resources/cop_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        solar_thermal_total="resources/solar_thermal_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        solar_thermal_urban="resources/solar_thermal_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        solar_thermal_rural="resources/solar_thermal_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
         **build_retro_cost_output,
         **build_biomass_transport_costs_output,
         **gas_infrastructure
-    output: RDIR + '/prenetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
+    output: RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
     threads: 1
     resources: mem_mb=2000
-    benchmark: RDIR + "/benchmarks/prepare_network/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+    benchmark: RDIR + "/benchmarks/prepare_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
     script: "scripts/prepare_sector_network.py"
 
 
 rule plot_network:
     input:
         overrides="data/override_component_attrs",
-        network=RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        network=RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
     output:
-        map=RDIR + "/maps/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
-        today=RDIR + "/maps/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}-today.pdf"
+        map=RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
+        today=RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}-today.pdf"
     threads: 2
     resources: mem_mb=10000
-    benchmark: RDIR + "/benchmarks/plot_network/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+    benchmark: RDIR + "/benchmarks/plot_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
     script: "scripts/plot_network.py"
 
 
@@ -500,12 +501,12 @@ rule make_summary:
     input:
         overrides="data/override_component_attrs",
         networks=expand(
-            RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             **config['scenario']
         ),
         costs=CDIR + "costs_{}.csv".format(config['scenario']['planning_horizons'][0]),
         plots=expand(
-            RDIR + "/maps/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
+            RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
             **config['scenario']
         )
     output:
@@ -550,18 +551,18 @@ if config["foresight"] == "overnight":
     rule solve_network:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + "/prenetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            network=RDIR + "/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             config=SDIR + '/configs/config.yaml'
-        output: RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        output: RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         shadow: "shallow"
         log:
-            solver=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
-            python=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
-            memory=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
+            solver=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
+            python=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
+            memory=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
         threads: config['solving']['solver'].get('threads', 4)
         resources: mem_mb=config['solving']['mem']
-        benchmark: RDIR + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+        benchmark: RDIR + "/benchmarks/solve_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
         script: "scripts/solve_network.py"
 
 
@@ -570,25 +571,25 @@ if config["foresight"] == "myopic":
     rule add_existing_baseyear:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + '/prenetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
+            network=RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
             powerplants=pypsaeur('resources/powerplants.csv'),
-            busmap_s=pypsaeur("resources/busmap_elec_s{simpl}.csv"),
-            busmap=pypsaeur("resources/busmap_elec_s{simpl}_{clusters}.csv"),
-            clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
+            busmap_s=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}.csv"),
+            busmap=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}_{clusters}.csv"),
+            clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
             costs=CDIR + "costs_{}.csv".format(config['scenario']['planning_horizons'][0]),
-            cop_soil_total="resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-            cop_air_total="resources/cop_air_total_elec_s{simpl}_{clusters}.nc",
+            cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+            cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
             existing_heating='data/existing_infrastructure/existing_heating_raw.csv',
             country_codes='data/Country_codes.csv',
             existing_solar='data/existing_infrastructure/solar_capacity_IRENA.csv',
             existing_onwind='data/existing_infrastructure/onwind_capacity_IRENA.csv',
             existing_offwind='data/existing_infrastructure/offwind_capacity_IRENA.csv',
-        output: RDIR + '/prenetworks-brownfield/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
+        output: RDIR + '/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
         wildcard_constraints:
             planning_horizons=config['scenario']['planning_horizons'][0] #only applies to baseyear
         threads: 1
         resources: mem_mb=2000
-        benchmark: RDIR + '/benchmarks/add_existing_baseyear/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
+        benchmark: RDIR + '/benchmarks/add_existing_baseyear/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
         script: "scripts/add_existing_baseyear.py"
 
 
@@ -596,21 +597,21 @@ if config["foresight"] == "myopic":
         planning_horizons = config["scenario"]["planning_horizons"]
         i = planning_horizons.index(int(wildcards.planning_horizons))
         planning_horizon_p = str(planning_horizons[i-1])
-        return RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_" + planning_horizon_p + ".nc"
+        return RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_" + planning_horizon_p + ".nc"
 
 
     rule add_brownfield:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + '/prenetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
+            network=RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
             network_p=solved_previous_horizon, #solved network at previous time step
             costs=CDIR + "costs_{planning_horizons}.csv",
-            cop_soil_total="resources/cop_soil_total_elec_s{simpl}_{clusters}.nc",
-            cop_air_total="resources/cop_air_total_elec_s{simpl}_{clusters}.nc"
-        output: RDIR + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+            cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+            cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        output: RDIR + "/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         threads: 4
         resources: mem_mb=10000
-        benchmark: RDIR + '/benchmarks/add_brownfield/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
+        benchmark: RDIR + '/benchmarks/add_brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
         script: "scripts/add_brownfield.py"
 
 
@@ -620,16 +621,16 @@ if config["foresight"] == "myopic":
     rule solve_network_myopic:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + "/prenetworks-brownfield/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            network=RDIR + "/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             config=SDIR + '/configs/config.yaml'
-        output: RDIR + "/postnetworks/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        output: RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         shadow: "shallow"
         log:
-            solver=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
-            python=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
-            memory=RDIR + "/logs/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
+            solver=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
+            python=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
+            memory=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
         threads: 4
         resources: mem_mb=config['solving']['mem']
-        benchmark: RDIR + "/benchmarks/solve_network/elec_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+        benchmark: RDIR + "/benchmarks/solve_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
         script: "scripts/solve_network.py"

--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,3 @@
-
 from os.path import exists
 from shutil import copyfile
 
@@ -67,25 +66,25 @@ rule build_population_layouts:
         nuts3_shapes=pypsaeur('resources/nuts3_shapes.geojson'),
         urban_percent="data/urban_percent.csv"
     output:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc"
+        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
+        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_population_layouts"
+    benchmark: "benchmarks/build_population_layouts{weatheryear}"
     threads: 8
     script: "scripts/build_population_layouts.py"
 
 
 rule build_clustered_population_layouts:
     input:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc",
+        pop_layout_total="resources/pop_layout_total{weatheryear}.nc",
+        pop_layout_urban="resources/pop_layout_urban{weatheryear}.nc",
+        pop_layout_rural="resources/pop_layout_rural{weatheryear}.nc",
         regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson')
     output:
         clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv"
     resources: mem_mb=10000
-    benchmark: "benchmarks/build_clustered_population_layouts/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_clustered_population_layouts/{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_clustered_population_layouts.py"
 
 
@@ -98,7 +97,7 @@ rule build_simplified_population_layouts:
     output:
         clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}.csv"
     resources: mem_mb=10000
-    benchmark: "benchmarks/build_clustered_population_layouts/s{simpl}"
+    benchmark: "benchmarks/build_clustered_population_layouts/{weatheryear}_s{simpl}"
     script: "scripts/build_clustered_population_layouts.py"
 
 
@@ -159,24 +158,24 @@ else:
 
 rule build_heat_demands:
     input:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc",
+        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
+        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc",
         regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
     output:
         heat_demand_urban="resources/heat_demand_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
         heat_demand_rural="resources/heat_demand_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
         heat_demand_total="resources/heat_demand_total_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_heat_demands/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_heat_demands/{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_heat_demand.py"
 
 
 rule build_temperature_profiles:
     input:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc",
+        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
+        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc",
         regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
     output:
         temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
@@ -186,7 +185,7 @@ rule build_temperature_profiles:
         temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
         temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_temperature_profiles/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_temperature_profiles/{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_temperature_profiles.py"
 
 
@@ -206,7 +205,7 @@ rule build_cop_profiles:
         cop_air_rural="resources/cop_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
         cop_air_urban="resources/cop_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_cop_profiles/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_cop_profiles/{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_cop_profiles.py"
 
 
@@ -221,7 +220,7 @@ rule build_solar_thermal_profiles:
         solar_thermal_urban="resources/solar_thermal_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
         solar_thermal_rural="resources/solar_thermal_rural_elec{weatheryear}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_solar_thermal_profiles/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_solar_thermal_profiles/{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_solar_thermal_profiles.py"
 
 
@@ -258,11 +257,11 @@ rule build_biomass_potentials:
         swiss_population="../pypsa-eur/data/bundle/je-e-21.03.02.xls",
         country_shapes=pypsaeur('resources/country_shapes.geojson')
     output:
-        biomass_potentials_all='resources/biomass_potentials_all_s{simpl}_{clusters}.csv',
-        biomass_potentials='resources/biomass_potentials_s{simpl}_{clusters}.csv'
+        biomass_potentials_all='resources/biomass_potentials_all{weatheryear}_s{simpl}_{clusters}.csv',
+        biomass_potentials='resources/biomass_potentials{weatheryear}_s{simpl}_{clusters}.csv'
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_biomass_potentials_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_biomass_potentials{weatheryear}_s{simpl}_{clusters}"
     script: 'scripts/build_biomass_potentials.py'
 
 
@@ -287,10 +286,10 @@ rule build_salt_cavern_potentials:
         regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
         regions_offshore=pypsaeur("resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
     output:
-        h2_cavern_potential="resources/salt_cavern_potentials_s{simpl}_{clusters}.csv"
+        h2_cavern_potential="resources/salt_cavern_potentials{weatheryear}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=2000
-    benchmark: "benchmarks/build_salt_cavern_potentials_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_salt_cavern_potentials{weatheryear}_s{simpl}_{clusters}"
     script: "scripts/build_salt_cavern_potentials.py"
 
 
@@ -350,7 +349,7 @@ rule build_industrial_distribution_key:
         industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_distribution_key/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_industrial_distribution_key/{weatheryear}_s{simpl}_{clusters}"
     script: 'scripts/build_industrial_distribution_key.py'
 
 
@@ -362,7 +361,7 @@ rule build_industrial_production_per_node:
         industrial_production_per_node="resources/industrial_production_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_production_per_node/s{simpl}_{clusters}_{planning_horizons}"
+    benchmark: "benchmarks/build_industrial_production_per_node/{weatheryear}_s{simpl}_{clusters}_{planning_horizons}"
     script: 'scripts/build_industrial_production_per_node.py'
 
 
@@ -375,7 +374,7 @@ rule build_industrial_energy_demand_per_node:
         industrial_energy_demand_per_node="resources/industrial_energy_demand_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_energy_demand_per_node/s{simpl}_{clusters}_{planning_horizons}"
+    benchmark: "benchmarks/build_industrial_energy_demand_per_node/{weatheryear}_s{simpl}_{clusters}_{planning_horizons}"
     script: 'scripts/build_industrial_energy_demand_per_node.py'
 
 
@@ -400,7 +399,7 @@ rule build_industrial_energy_demand_per_node_today:
         industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weatheryear}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_energy_demand_per_node_today/s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_industrial_energy_demand_per_node_today/{weatheryear}_s{simpl}_{clusters}"
     script: 'scripts/build_industrial_energy_demand_per_node_today.py'
 
 
@@ -421,7 +420,7 @@ if config["sector"]["retrofitting"]["retro_endogen"]:
             retro_cost="resources/retro_cost_elec{weatheryear}_s{simpl}_{clusters}.csv",
             floor_area="resources/floor_area_elec{weatheryear}_s{simpl}_{clusters}.csv"
         resources: mem_mb=1000
-        benchmark: "benchmarks/build_retro_cost/s{simpl}_{clusters}"
+        benchmark: "benchmarks/build_retro_cost/{weatheryear}_s{simpl}_{clusters}"
         script: "scripts/build_retro_cost.py"
     build_retro_cost_output = rules.build_retro_cost.output
 else:

--- a/Snakefile
+++ b/Snakefile
@@ -11,12 +11,13 @@ configfile: "config.yaml"
 
 
 wildcard_constraints:
-    weatheryear="[0-9]*",
-    lv="[a-z0-9\.]+",
     simpl="[a-zA-Z0-9]*",
+    weather_year="[0-9]+m?",  
     clusters="[0-9]+m?",
+    lv="[a-z0-9\.]+",
     opts="[-+a-zA-Z0-9]*",
-    sector_opts="[-+a-zA-Z0-9\.\s]*"
+    sector_opts="[-+a-zA-Z0-9\.\s]*"#,
+    # investment_year="[0-9]+m?",
 
 
 SDIR = config['summary_dir'] + '/' + config['run']
@@ -35,13 +36,13 @@ rule all:
 
 rule solve_all_networks:
     input:
-        expand(RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        expand(RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
                **config['scenario'])
 
 
 rule prepare_sector_networks:
     input:
-        expand(RDIR + "/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+        expand(RDIR + "/prenetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
                **config['scenario'])
 
 datafiles = [
@@ -66,38 +67,40 @@ rule build_population_layouts:
         nuts3_shapes=pypsaeur('resources/nuts3_shapes.geojson'),
         urban_percent="data/urban_percent.csv"
     output:
-        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
-        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
-        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc"
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_population_layouts{weatheryear}"
+    benchmark: "benchmarks/build_population_layouts{weather_year}"
     threads: 8
     script: "scripts/build_population_layouts.py"
 
 
 rule build_clustered_population_layouts:
     input:
-        pop_layout_total="resources/pop_layout_total{weatheryear}.nc",
-        pop_layout_urban="resources/pop_layout_urban{weatheryear}.nc",
-        pop_layout_rural="resources/pop_layout_rural{weatheryear}.nc",
-        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson')
+        cutout = pypsaeur('cutouts/europe-{weather_year}-era5.nc'),
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc",
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson')
     output:
-        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv"
+        clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}_{clusters}.csv"
     resources: mem_mb=10000
-    benchmark: "benchmarks/build_clustered_population_layouts/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_clustered_population_layouts/{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_clustered_population_layouts.py"
 
 
 rule build_simplified_population_layouts:
     input:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}.geojson')
+        cutout = pypsaeur('cutouts/europe-{weather_year}-era5.nc'),
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc",
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weather_year}_s{simpl}.geojson')
     output:
-        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}.csv"
+        clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}.csv"
     resources: mem_mb=10000
-    benchmark: "benchmarks/build_clustered_population_layouts/{weatheryear}_s{simpl}"
+    benchmark: "benchmarks/build_clustered_population_layouts/{weather_year}_s{simpl}"
     script: "scripts/build_clustered_population_layouts.py"
 
 
@@ -131,8 +134,8 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
             entry="data/gas_network/scigrid-gas/data/IGGIELGN_BorderPoints.geojson",
             production="data/gas_network/scigrid-gas/data/IGGIELGN_Productions.geojson",
             planned_lng="data/gas_network/planned_LNGs.csv",
-            regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
-            regions_offshore=pypsaeur('resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson')
+            regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson"),
+            regions_offshore=pypsaeur('resources/regions_offshore_elec{weather_year}_s{simpl}_{clusters}.geojson')
         output:
             gas_input_nodes="resources/gas_input_locations_s{simpl}_{clusters}.geojson",
             gas_input_nodes_simplified="resources/gas_input_locations_s{simpl}_{clusters}_simplified.csv"
@@ -143,10 +146,10 @@ if config["sector"]["gas_network"] or config["sector"]["H2_retrofit"]:
     rule cluster_gas_network:
         input:
             cleaned_gas_network="resources/gas_network.csv",
-            regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
-            regions_offshore=pypsaeur("resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
+            regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson"),
+            regions_offshore=pypsaeur("resources/regions_offshore_elec{weather_year}_s{simpl}_{clusters}.geojson")
         output:
-            clustered_gas_network="resources/gas_network_elec{weatheryear}_s{simpl}_{clusters}.csv"
+            clustered_gas_network="resources/gas_network_elec{weather_year}_s{simpl}_{clusters}.csv"
         resources: mem_mb=4000
         script: "scripts/cluster_gas_network.py"
 
@@ -158,69 +161,72 @@ else:
 
 rule build_heat_demands:
     input:
-        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
-        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
-        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
+        cutout = pypsaeur('cutouts/europe-{weather_year}-era5.nc'),
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc",
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson")
     output:
-        heat_demand_urban="resources/heat_demand_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        heat_demand_rural="resources/heat_demand_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        heat_demand_total="resources/heat_demand_total_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        heat_demand_urban="resources/heat_demand_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        heat_demand_rural="resources/heat_demand_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        heat_demand_total="resources/heat_demand_total_elec{weather_year}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_heat_demands/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_heat_demands/{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_heat_demand.py"
 
 
 rule build_temperature_profiles:
     input:
-        pop_layout_total="resources/pop_layout{weatheryear}_total.nc",
-        pop_layout_urban="resources/pop_layout{weatheryear}_urban.nc",
-        pop_layout_rural="resources/pop_layout{weatheryear}_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
+        cutout = pypsaeur('cutouts/europe-{weather_year}-era5.nc'),
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc",
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson")
     output:
-        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        temp_soil_total="resources/temp_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weather_year}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_temperature_profiles/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_temperature_profiles/{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_temperature_profiles.py"
 
 
 rule build_cop_profiles:
     input:
-        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        temp_soil_total="resources/temp_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weather_year}_s{simpl}_{clusters}.nc"
     output:
-        cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_soil_rural="resources/cop_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_soil_urban="resources/cop_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_rural="resources/cop_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_urban="resources/cop_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        cop_soil_total="resources/cop_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_soil_rural="resources/cop_soil_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_soil_urban="resources/cop_soil_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_total="resources/cop_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_rural="resources/cop_air_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_urban="resources/cop_air_urban_elec{weather_year}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_cop_profiles/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_cop_profiles/{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_cop_profiles.py"
 
 
 rule build_solar_thermal_profiles:
     input:
-        pop_layout_total="resources/pop_layout_total.nc",
-        pop_layout_urban="resources/pop_layout_urban.nc",
-        pop_layout_rural="resources/pop_layout_rural.nc",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson")
+        cutout = pypsaeur('cutouts/europe-{weather_year}-era5.nc'),
+        pop_layout_total="resources/pop_layout{weather_year}_total.nc",
+        pop_layout_urban="resources/pop_layout{weather_year}_urban.nc",
+        pop_layout_rural="resources/pop_layout{weather_year}_rural.nc",
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson")
     output:
-        solar_thermal_total="resources/solar_thermal_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        solar_thermal_urban="resources/solar_thermal_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        solar_thermal_rural="resources/solar_thermal_rural_elec{weatheryear}_s{simpl}_{clusters}.nc"
+        solar_thermal_total="resources/solar_thermal_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        solar_thermal_urban="resources/solar_thermal_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        solar_thermal_rural="resources/solar_thermal_rural_elec{weather_year}_s{simpl}_{clusters}.nc"
     resources: mem_mb=20000
-    benchmark: "benchmarks/build_solar_thermal_profiles/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_solar_thermal_profiles/{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_solar_thermal_profiles.py"
 
 
@@ -251,17 +257,17 @@ rule build_biomass_potentials:
     input:
         enspreso_biomass=HTTP.remote("https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx", keep_local=True),
         nuts2="data/nuts/NUTS_RG_10M_2013_4326_LEVL_2.geojson", # https://gisco-services.ec.europa.eu/distribution/v2/nuts/download/#nuts21
-        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson"),
         nuts3_population="../pypsa-eur/data/bundle/nama_10r_3popgdp.tsv.gz",
         swiss_cantons="../pypsa-eur/data/bundle/ch_cantons.csv",
         swiss_population="../pypsa-eur/data/bundle/je-e-21.03.02.xls",
         country_shapes=pypsaeur('resources/country_shapes.geojson')
     output:
-        biomass_potentials_all='resources/biomass_potentials_all{weatheryear}_s{simpl}_{clusters}.csv',
-        biomass_potentials='resources/biomass_potentials{weatheryear}_s{simpl}_{clusters}.csv'
+        biomass_potentials_all='resources/biomass_potentials_all{weather_year}_s{simpl}_{clusters}.csv',
+        biomass_potentials='resources/biomass_potentials{weather_year}_s{simpl}_{clusters}.csv'
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_biomass_potentials{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_biomass_potentials{weather_year}_s{simpl}_{clusters}"
     script: 'scripts/build_biomass_potentials.py'
 
 
@@ -283,13 +289,13 @@ else:
 rule build_salt_cavern_potentials:
     input:
         salt_caverns="data/h2_salt_caverns_GWh_per_sqkm.geojson",
-        regions_onshore=pypsaeur("resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
-        regions_offshore=pypsaeur("resources/regions_offshore_elec{weatheryear}_s{simpl}_{clusters}.geojson"),
+        regions_onshore=pypsaeur("resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson"),
+        regions_offshore=pypsaeur("resources/regions_offshore_elec{weather_year}_s{simpl}_{clusters}.geojson"),
     output:
-        h2_cavern_potential="resources/salt_cavern_potentials{weatheryear}_s{simpl}_{clusters}.csv"
+        h2_cavern_potential="resources/salt_cavern_potentials{weather_year}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=2000
-    benchmark: "benchmarks/build_salt_cavern_potentials{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_salt_cavern_potentials{weather_year}_s{simpl}_{clusters}"
     script: "scripts/build_salt_cavern_potentials.py"
 
 
@@ -342,39 +348,39 @@ rule build_industrial_production_per_country_tomorrow:
 
 rule build_industrial_distribution_key:
     input:
-        regions_onshore=pypsaeur('resources/regions_onshore_elec{weatheryear}_s{simpl}_{clusters}.geojson'),
-        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
+        regions_onshore=pypsaeur('resources/regions_onshore_elec{weather_year}_s{simpl}_{clusters}.geojson'),
+        clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}_{clusters}.csv",
         hotmaps_industrial_database="data/Industrial_Database.csv",
     output:
-        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv"
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weather_year}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_distribution_key/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_industrial_distribution_key/{weather_year}_s{simpl}_{clusters}"
     script: 'scripts/build_industrial_distribution_key.py'
 
 
 rule build_industrial_production_per_node:
     input:
-        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv",
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weather_year}_s{simpl}_{clusters}.csv",
         industrial_production_per_country_tomorrow="resources/industrial_production_per_country_tomorrow_{planning_horizons}.csv"
     output:
-        industrial_production_per_node="resources/industrial_production_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
+        industrial_production_per_node="resources/industrial_production_elec{weather_year}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_production_per_node/{weatheryear}_s{simpl}_{clusters}_{planning_horizons}"
+    benchmark: "benchmarks/build_industrial_production_per_node/{weather_year}_s{simpl}_{clusters}_{planning_horizons}"
     script: 'scripts/build_industrial_production_per_node.py'
 
 
 rule build_industrial_energy_demand_per_node:
     input:
         industry_sector_ratios="resources/industry_sector_ratios.csv",
-        industrial_production_per_node="resources/industrial_production_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv",
-        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weatheryear}_s{simpl}_{clusters}.csv"
+        industrial_production_per_node="resources/industrial_production_elec{weather_year}_s{simpl}_{clusters}_{planning_horizons}.csv",
+        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weather_year}_s{simpl}_{clusters}.csv"
     output:
-        industrial_energy_demand_per_node="resources/industrial_energy_demand_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv"
+        industrial_energy_demand_per_node="resources/industrial_energy_demand_elec{weather_year}_s{simpl}_{clusters}_{planning_horizons}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_energy_demand_per_node/{weatheryear}_s{simpl}_{clusters}_{planning_horizons}"
+    benchmark: "benchmarks/build_industrial_energy_demand_per_node/{weather_year}_s{simpl}_{clusters}_{planning_horizons}"
     script: 'scripts/build_industrial_energy_demand_per_node.py'
 
 
@@ -393,13 +399,13 @@ rule build_industrial_energy_demand_per_country_today:
 
 rule build_industrial_energy_demand_per_node_today:
     input:
-        industrial_distribution_key="resources/industrial_distribution_key_elec{weatheryear}_s{simpl}_{clusters}.csv",
+        industrial_distribution_key="resources/industrial_distribution_key_elec{weather_year}_s{simpl}_{clusters}.csv",
         industrial_energy_demand_per_country_today="resources/industrial_energy_demand_per_country_today.csv"
     output:
-        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weatheryear}_s{simpl}_{clusters}.csv"
+        industrial_energy_demand_per_node_today="resources/industrial_energy_demand_today_elec{weather_year}_s{simpl}_{clusters}.csv"
     threads: 1
     resources: mem_mb=1000
-    benchmark: "benchmarks/build_industrial_energy_demand_per_node_today/{weatheryear}_s{simpl}_{clusters}"
+    benchmark: "benchmarks/build_industrial_energy_demand_per_node_today/{weather_year}_s{simpl}_{clusters}"
     script: 'scripts/build_industrial_energy_demand_per_node_today.py'
 
 
@@ -408,19 +414,19 @@ if config["sector"]["retrofitting"]["retro_endogen"]:
         input:
             building_stock="data/retro/data_building_stock.csv",
             data_tabula="data/retro/tabula-calculator-calcsetbuilding.csv",
-            air_temperature = "resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+            air_temperature = "resources/temp_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
             u_values_PL="data/retro/u_values_poland.csv",
             tax_w="data/retro/electricity_taxes_eu.csv",
             construction_index="data/retro/comparative_level_investment.csv",
             floor_area_missing="data/retro/floor_area_missing.csv",
-            clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
+            clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}_{clusters}.csv",
             cost_germany="data/retro/retro_cost_germany.csv",
             window_assumptions="data/retro/window_assumptions.csv",
         output:
-            retro_cost="resources/retro_cost_elec{weatheryear}_s{simpl}_{clusters}.csv",
-            floor_area="resources/floor_area_elec{weatheryear}_s{simpl}_{clusters}.csv"
+            retro_cost="resources/retro_cost_elec{weather_year}_s{simpl}_{clusters}.csv",
+            floor_area="resources/floor_area_elec{weather_year}_s{simpl}_{clusters}.csv"
         resources: mem_mb=1000
-        benchmark: "benchmarks/build_retro_cost/{weatheryear}_s{simpl}_{clusters}"
+        benchmark: "benchmarks/build_retro_cost/{weather_year}_s{simpl}_{clusters}"
         script: "scripts/build_retro_cost.py"
     build_retro_cost_output = rules.build_retro_cost.output
 else:
@@ -430,61 +436,61 @@ else:
 rule prepare_sector_network:
     input:
         overrides="data/override_component_attrs",
-        network=pypsaeur('networks/elec{weatheryear}_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
+        network=pypsaeur('networks/elec{weather_year}_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
         energy_totals_name='resources/energy_totals.csv',
         co2_totals_name='resources/co2_totals.csv',
         transport_name='resources/transport_data.csv',
         traffic_data_KFZ="data/emobility/KFZ__count",
         traffic_data_Pkw="data/emobility/Pkw__count",
-        biomass_potentials='resources/biomass_potentials_s{simpl}_{clusters}.csv',
+        biomass_potentials='resources/biomass_potentials{weather_year}_s{simpl}_{clusters}.csv',
         heat_profile="data/heat_load_profile_BDEW.csv",
         costs=CDIR + "costs_{planning_horizons}.csv",
-        profile_offwind_ac=pypsaeur("resources/profile_offwind-ac.nc"),
-        profile_offwind_dc=pypsaeur("resources/profile_offwind-dc.nc"),
-        h2_cavern="resources/salt_cavern_potentials_s{simpl}_{clusters}.csv",
-        busmap_s=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}.csv"),
-        busmap=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}_{clusters}.csv"),
-        clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
-        simplified_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}.csv",
-        industrial_demand="resources/industrial_energy_demand_elec{weatheryear}_s{simpl}_{clusters}_{planning_horizons}.csv",
-        heat_demand_urban="resources/heat_demand_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        heat_demand_rural="resources/heat_demand_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        heat_demand_total="resources/heat_demand_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_total="resources/temp_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_rural="resources/temp_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_soil_urban="resources/temp_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_total="resources/temp_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_rural="resources/temp_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        temp_air_urban="resources/temp_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_soil_rural="resources/cop_soil_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_soil_urban="resources/cop_soil_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_rural="resources/cop_air_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        cop_air_urban="resources/cop_air_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        solar_thermal_total="resources/solar_thermal_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        solar_thermal_urban="resources/solar_thermal_urban_elec{weatheryear}_s{simpl}_{clusters}.nc",
-        solar_thermal_rural="resources/solar_thermal_rural_elec{weatheryear}_s{simpl}_{clusters}.nc",
+        profile_offwind_ac=pypsaeur("resources/profile{weather_year}_offwind-ac.nc"),
+        profile_offwind_dc=pypsaeur("resources/profile{weather_year}_offwind-dc.nc"),
+        h2_cavern="resources/salt_cavern_potentials{weather_year}_s{simpl}_{clusters}.csv",
+        busmap_s=pypsaeur("resources/busmap_elec{weather_year}_s{simpl}.csv"),
+        busmap=pypsaeur("resources/busmap_elec{weather_year}_s{simpl}_{clusters}.csv"),
+        clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}_{clusters}.csv",
+        simplified_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}.csv",
+        industrial_demand="resources/industrial_energy_demand_elec{weather_year}_s{simpl}_{clusters}_{planning_horizons}.csv",
+        heat_demand_urban="resources/heat_demand_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        heat_demand_rural="resources/heat_demand_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        heat_demand_total="resources/heat_demand_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_total="resources/temp_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_rural="resources/temp_soil_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_soil_urban="resources/temp_soil_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_total="resources/temp_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_rural="resources/temp_air_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        temp_air_urban="resources/temp_air_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_soil_total="resources/cop_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_soil_rural="resources/cop_soil_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_soil_urban="resources/cop_soil_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_total="resources/cop_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_rural="resources/cop_air_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
+        cop_air_urban="resources/cop_air_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        solar_thermal_total="resources/solar_thermal_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+        solar_thermal_urban="resources/solar_thermal_urban_elec{weather_year}_s{simpl}_{clusters}.nc",
+        solar_thermal_rural="resources/solar_thermal_rural_elec{weather_year}_s{simpl}_{clusters}.nc",
         **build_retro_cost_output,
         **build_biomass_transport_costs_output,
         **gas_infrastructure
-    output: RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
+    output: RDIR + '/prenetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
     threads: 1
     resources: mem_mb=2000
-    benchmark: RDIR + "/benchmarks/prepare_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+    benchmark: RDIR + "/benchmarks/prepare_network/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
     script: "scripts/prepare_sector_network.py"
 
 
 rule plot_network:
     input:
         overrides="data/override_component_attrs",
-        network=RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        network=RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
     output:
-        map=RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
-        today=RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}-today.pdf"
+        map=RDIR + "/maps/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
+        today=RDIR + "/maps/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}-today.pdf"
     threads: 2
     resources: mem_mb=10000
-    benchmark: RDIR + "/benchmarks/plot_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+    benchmark: RDIR + "/benchmarks/plot_network/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
     script: "scripts/plot_network.py"
 
 
@@ -500,12 +506,12 @@ rule make_summary:
     input:
         overrides="data/override_component_attrs",
         networks=expand(
-            RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             **config['scenario']
         ),
         costs=CDIR + "costs_{}.csv".format(config['scenario']['planning_horizons'][0]),
         plots=expand(
-            RDIR + "/maps/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
+            RDIR + "/maps/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}-costs-all_{planning_horizons}.pdf",
             **config['scenario']
         )
     output:
@@ -550,18 +556,18 @@ if config["foresight"] == "overnight":
     rule solve_network:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + "/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            network=RDIR + "/prenetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             config=SDIR + '/configs/config.yaml'
-        output: RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        output: RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         shadow: "shallow"
         log:
-            solver=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
-            python=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
-            memory=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
+            solver=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
+            python=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
+            memory=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
         threads: config['solving']['solver'].get('threads', 4)
         resources: mem_mb=config['solving']['mem']
-        benchmark: RDIR + "/benchmarks/solve_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+        benchmark: RDIR + "/benchmarks/solve_network/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
         script: "scripts/solve_network.py"
 
 
@@ -570,25 +576,25 @@ if config["foresight"] == "myopic":
     rule add_existing_baseyear:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
+            network=RDIR + '/prenetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
             powerplants=pypsaeur('resources/powerplants.csv'),
-            busmap_s=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}.csv"),
-            busmap=pypsaeur("resources/busmap_elec{weatheryear}_s{simpl}_{clusters}.csv"),
-            clustered_pop_layout="resources/pop_layout_elec{weatheryear}_s{simpl}_{clusters}.csv",
+            busmap_s=pypsaeur("resources/busmap_elec{weather_year}_s{simpl}.csv"),
+            busmap=pypsaeur("resources/busmap_elec{weather_year}_s{simpl}_{clusters}.csv"),
+            clustered_pop_layout="resources/pop_layout_elec{weather_year}_s{simpl}_{clusters}.csv",
             costs=CDIR + "costs_{}.csv".format(config['scenario']['planning_horizons'][0]),
-            cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-            cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
+            cop_soil_total="resources/cop_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+            cop_air_total="resources/cop_air_total_elec{weather_year}_s{simpl}_{clusters}.nc",
             existing_heating='data/existing_infrastructure/existing_heating_raw.csv',
             country_codes='data/Country_codes.csv',
             existing_solar='data/existing_infrastructure/solar_capacity_IRENA.csv',
             existing_onwind='data/existing_infrastructure/onwind_capacity_IRENA.csv',
             existing_offwind='data/existing_infrastructure/offwind_capacity_IRENA.csv',
-        output: RDIR + '/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
+        output: RDIR + '/prenetworks-brownfield/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc'
         wildcard_constraints:
             planning_horizons=config['scenario']['planning_horizons'][0] #only applies to baseyear
         threads: 1
         resources: mem_mb=2000
-        benchmark: RDIR + '/benchmarks/add_existing_baseyear/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
+        benchmark: RDIR + '/benchmarks/add_existing_baseyear/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
         script: "scripts/add_existing_baseyear.py"
 
 
@@ -596,21 +602,21 @@ if config["foresight"] == "myopic":
         planning_horizons = config["scenario"]["planning_horizons"]
         i = planning_horizons.index(int(wildcards.planning_horizons))
         planning_horizon_p = str(planning_horizons[i-1])
-        return RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_" + planning_horizon_p + ".nc"
+        return RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_" + planning_horizon_p + ".nc"
 
 
     rule add_brownfield:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + '/prenetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
+            network=RDIR + '/prenetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc',
             network_p=solved_previous_horizon, #solved network at previous time step
             costs=CDIR + "costs_{planning_horizons}.csv",
-            cop_soil_total="resources/cop_soil_total_elec{weatheryear}_s{simpl}_{clusters}.nc",
-            cop_air_total="resources/cop_air_total_elec{weatheryear}_s{simpl}_{clusters}.nc"
-        output: RDIR + "/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+            cop_soil_total="resources/cop_soil_total_elec{weather_year}_s{simpl}_{clusters}.nc",
+            cop_air_total="resources/cop_air_total_elec{weather_year}_s{simpl}_{clusters}.nc"
+        output: RDIR + "/prenetworks-brownfield/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         threads: 4
         resources: mem_mb=10000
-        benchmark: RDIR + '/benchmarks/add_brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
+        benchmark: RDIR + '/benchmarks/add_brownfield/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}'
         script: "scripts/add_brownfield.py"
 
 
@@ -620,16 +626,16 @@ if config["foresight"] == "myopic":
     rule solve_network_myopic:
         input:
             overrides="data/override_component_attrs",
-            network=RDIR + "/prenetworks-brownfield/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
+            network=RDIR + "/prenetworks-brownfield/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc",
             costs=CDIR + "costs_{planning_horizons}.csv",
             config=SDIR + '/configs/config.yaml'
-        output: RDIR + "/postnetworks/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
+        output: RDIR + "/postnetworks/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}.nc"
         shadow: "shallow"
         log:
-            solver=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
-            python=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
-            memory=RDIR + "/logs/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
+            solver=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_solver.log",
+            python=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_python.log",
+            memory=RDIR + "/logs/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}_memory.log"
         threads: 4
         resources: mem_mb=config['solving']['mem']
-        benchmark: RDIR + "/benchmarks/solve_network/elec{weatheryear}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
+        benchmark: RDIR + "/benchmarks/solve_network/elec{weather_year}_s{simpl}_{clusters}_lv{lv}_{opts}_{sector_opts}_{planning_horizons}"
         script: "scripts/solve_network.py"

--- a/Snakefile
+++ b/Snakefile
@@ -12,7 +12,7 @@ configfile: "config.yaml"
 
 wildcard_constraints:
     simpl="[a-zA-Z0-9]*",
-    weather_year="[0-9]*", #"[a-zA-Z0-9]*", #"[0-9]*", #m?",  # "[0-9]*m?" * means that it can be empty + means it can only be nonempty
+    weather_year="[0-9]*",
     clusters="[0-9]+m?",
     lv="[a-z0-9\.]+",
     opts="[-+a-zA-Z0-9]*",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -7,25 +7,33 @@ retrieve_sector_databundle: true
 results_dir: results/
 summary_dir: results
 costs_dir: ../technology-data/outputs/
-run: your-run-name  # use this to keep track of runs with different settings
+run: multiyear  # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
-# if you use myopic or perfect foresight, set the investment years in "planning_horizons" below
+# if you use myopic or perfect foresight, set the investment years in "investment_year" below
 
 scenario:
   simpl: # only relevant for PyPSA-Eur
     - ''
-  weatheryear:
-    - 2011
+  weather_year: # year used for weather data (solar irradiance, wind velocity, runoff)
+    - '2004'
+
   lv: # allowed transmission line volume expansion, can be any float >= 1.0 (today) or "opt"
     - 1.0
-    - 1.5
   clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
-    - 45
-    - 50
+    - 37
   opts: # only relevant for PyPSA-Eur
     - ''
   sector_opts: # this is where the main scenario settings are
-    - Co2L0-3H-T-H-B-I-A-solar+p3-dist1
+    - Co2L0-3H-solar+p3-dist1
+    #- Co2L0-3H-T-H-B-I-A-solar+p3-dist1
+
+  # investment_year:
+  #   - 2030
+  #   - 2035
+  #   - 2040
+  #   - 2045
+  #   - 2050
+
   # to really understand the options here, look in scripts/prepare_sector_network.py
   # Co2Lx specifies the CO2 target in x% of the 1990 values; default will give default (5%);
   # Co2L0p25 will give 25% CO2 emissions; Co2Lm0p05 will give 5% negative emissions
@@ -42,8 +50,11 @@ scenario:
   # planning_horizons), be:beta decay; ex:exponential decay
   # cb40ex0 distributes a carbon budget of 40 GtCO2 following an exponential
   # decay with initial growth rate 0
+  
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
     - 2030
+
+  
   # for example, set to [2020, 2030, 2040, 2050] for myopic foresight
 
 # CO2 budget as a fraction of 1990 emissions
@@ -59,14 +70,14 @@ co2_budget:
   2050: 0
 
 # snapshots are originally set in PyPSA-Eur/config.yaml but used again by PyPSA-Eur-Sec
-snapshots:
+#snapshots: # Not used # Maybe use this instead for "load/year" in base_network.py to allow studies for more than one year
   # arguments to pd.date_range
-  start: "2013-01-01"
-  end: "2014-01-01"
-  closed: left # end is not inclusive
+  #start: "2011-01-01"
+  #end: "2012-01-01"
+  #closed: left # end is not inclusive
 
-atlite:
-  cutout: ../pypsa-eur/cutouts/europe-2013-era5.nc
+#atlite: # Not used - delete?
+#  cutout: ../pypsa-eur/cutouts/europe-2011-era5.nc
 
 # this information is NOT used but needed as an argument for
 # pypsa-eur/scripts/add_electricity.py/load_costs in make_summary.py
@@ -74,6 +85,9 @@ electricity:
   max_hours:
     battery: 6
     H2: 168
+
+load:
+  year: 2013
 
 # regulate what components with which carriers are kept from PyPSA-Eur;
 # some technologies are removed because they are implemented differently

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,7 +1,5 @@
 version: 0.6.0
 
-NEW LINE
-
 logging_level: INFO
 
 retrieve_sector_databundle: true

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -14,6 +14,8 @@ foresight: overnight # options are overnight, myopic, perfect (perfect is not ye
 scenario:
   simpl: # only relevant for PyPSA-Eur
     - ''
+  weatheryear:
+    - 2011
   lv: # allowed transmission line volume expansion, can be any float >= 1.0 (today) or "opt"
     - 1.0
     - 1.5

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -7,7 +7,7 @@ retrieve_sector_databundle: true
 results_dir: results/
 summary_dir: results
 costs_dir: ../technology-data/outputs/
-run: more_years # use this to keep track of runs with different settings
+run: your-run-name # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "investment_year" below
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -7,16 +7,16 @@ retrieve_sector_databundle: true
 results_dir: results/
 summary_dir: results
 costs_dir: ../technology-data/outputs/
-run: multiyear  # use this to keep track of runs with different settings
+run: more_years # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "investment_year" below
 
 scenario:
   simpl: # only relevant for PyPSA-Eur
     - ''
-  weather_year: # year used for weather data (solar irradiance, wind velocity, runoff)
+  weather_year: # year (if empty: 2013) used for weather data (solar irradiance, wind velocity, water runoff, temperature) [1979-2021]
     - '2004'
-
+    - '2013'
   lv: # allowed transmission line volume expansion, can be any float >= 1.0 (today) or "opt"
     - 1.0
   clusters: # number of nodes in Europe, any integer between 37 (1 node per country-zone) and several hundred
@@ -24,16 +24,7 @@ scenario:
   opts: # only relevant for PyPSA-Eur
     - ''
   sector_opts: # this is where the main scenario settings are
-    - Co2L0-3H-solar+p3-dist1
-    #- Co2L0-3H-T-H-B-I-A-solar+p3-dist1
-
-  # investment_year:
-  #   - 2030
-  #   - 2035
-  #   - 2040
-  #   - 2045
-  #   - 2050
-
+    - Co2L0-3H-T-H-B-I-A-solar+p3-dist1
   # to really understand the options here, look in scripts/prepare_sector_network.py
   # Co2Lx specifies the CO2 target in x% of the 1990 values; default will give default (5%);
   # Co2L0p25 will give 25% CO2 emissions; Co2Lm0p05 will give 5% negative emissions
@@ -50,12 +41,12 @@ scenario:
   # planning_horizons), be:beta decay; ex:exponential decay
   # cb40ex0 distributes a carbon budget of 40 GtCO2 following an exponential
   # decay with initial growth rate 0
-  
-  planning_horizons: # investment years for myopic and perfect; or costs year for overnight
+  investment_year: # investment and cost years for myopic or investment year for overnight
     - 2030
+    - 2040
+    - 2050
 
-  
-  # for example, set to [2020, 2030, 2040, 2050] for myopic foresight
+  # For myopic, available years: 2020, 2025, 2030, 2035, 2040, 2045, 2050
 
 # CO2 budget as a fraction of 1990 emissions
 # this is over-ridden if CO2Lx is set in sector_opts
@@ -69,15 +60,7 @@ co2_budget:
   2045: 0.0322580645
   2050: 0
 
-# snapshots are originally set in PyPSA-Eur/config.yaml but used again by PyPSA-Eur-Sec
-#snapshots: # Not used # Maybe use this instead for "load/year" in base_network.py to allow studies for more than one year
-  # arguments to pd.date_range
-  #start: "2011-01-01"
-  #end: "2012-01-01"
-  #closed: left # end is not inclusive
-
-#atlite: # Not used - delete?
-#  cutout: ../pypsa-eur/cutouts/europe-2011-era5.nc
+cutout: 'europe-era5'
 
 # this information is NOT used but needed as an argument for
 # pypsa-eur/scripts/add_electricity.py/load_costs in make_summary.py
@@ -87,7 +70,7 @@ electricity:
     H2: 168
 
 load:
-  year: 2013
+  year: 2013 # Year of historical electricity load 
 
 # regulate what components with which carriers are kept from PyPSA-Eur;
 # some technologies are removed because they are implemented differently
@@ -332,6 +315,7 @@ industry:
   # Material Economics (2019): https://materialeconomics.com/latest-updates/industrial-transformation-2050
 
 costs:
+  year: 2030 # Available cost years: 2020, 2025, 2030, 2035, 2040, 2045, 2050
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: 0.07

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,5 +1,7 @@
 version: 0.6.0
 
+NEW LINE
+
 logging_level: INFO
 
 retrieve_sector_databundle: true

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -85,13 +85,13 @@ if __name__ == "__main__":
             clusters=48,
             lv=1.0,
             sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-            planning_horizons=2030,
+            investment_year=2030,
         )
 
     print(snakemake.input.network_p)
     logging.basicConfig(level=snakemake.config['logging_level'])
 
-    year = int(snakemake.wildcards.planning_horizons)
+    year = int(snakemake.wildcards.investment_year)
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -447,7 +447,7 @@ if __name__ == "__main__":
             lv=1.0,
             opts='',
             sector_opts='Co2L0-168H-T-H-B-I-solar+p3-dist1',
-            planning_horizons=2020,
+            investment_year=2020,
         )
 
     logging.basicConfig(level=snakemake.config['logging_level'])
@@ -455,7 +455,7 @@ if __name__ == "__main__":
     options = snakemake.config["sector"]
     opts = snakemake.wildcards.sector_opts.split('-')
 
-    baseyear= snakemake.config['scenario']["planning_horizons"][0]
+    baseyear= snakemake.config['scenario']["investment_year"][0]
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
             clusters=48,
         )
 
-    cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
+    cutout = atlite.Cutout(snakemake.input.cutout)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_clustered_population_layouts.py
+++ b/scripts/build_clustered_population_layouts.py
@@ -15,7 +15,15 @@ if __name__ == '__main__':
             clusters=48,
         )
 
-    cutout = atlite.Cutout(snakemake.input.cutout)
+    weather_year = snakemake.wildcards.weather_year
+    cutout_source = snakemake.config['cutout'].split('-')[1]
+    if len(weather_year) > 0:
+        cutout_name = '../pypsa-eur/cutouts/europe-' + str(weather_year) + '-' + cutout_source + '.nc'
+    else:
+        cutout_name = '../pypsa-eur/cutouts/europe-2013-era5.nc'
+
+    print(cutout_name)
+    cutout = atlite.Cutout(cutout_name)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_heat_demand.py
+++ b/scripts/build_heat_demand.py
@@ -24,11 +24,17 @@ if __name__ == '__main__':
         snakemake.input = Dict()
         snakemake.output = Dict()
 
-    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+    weather_year = snakemake.wildcards.weather_year
+    cutout_source = snakemake.config['cutout'].split('-')[1]
     
-    # cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
+    if len(weather_year) > 0:
+        time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-' + str(weather_year) + '-' + cutout_source + '.nc'
+    else:
+        time = pd.date_range('2013-01-01','2014-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-2013-era5.nc'
+
+    cutout = atlite.Cutout(cutout_name).sel(time=time)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_heat_demand.py
+++ b/scripts/build_heat_demand.py
@@ -24,9 +24,11 @@ if __name__ == '__main__':
         snakemake.input = Dict()
         snakemake.output = Dict()
 
-    time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(cutout_config).sel(time=time)
+    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
+    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+    
+    # cutout_config = snakemake.config['atlite']['cutout']
+    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_industrial_production_per_country_tomorrow.py
+++ b/scripts/build_industrial_production_per_country_tomorrow.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
 
     config = snakemake.config["industry"]
 
-    investment_year = int(snakemake.wildcards.planning_horizons)
+    investment_year = int(snakemake.wildcards.investment_year)
 
     fn = snakemake.input.industrial_production_per_country
     production = pd.read_csv(fn, index_col=0)

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -14,7 +14,16 @@ if __name__ == '__main__':
         from helper import mock_snakemake
         snakemake = mock_snakemake('build_population_layouts')
 
-    cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
+    weather_year = snakemake.wildcards.weather_year
+    cutout_source = snakemake.config['cutout'].split('-')[1]
+    if len(weather_year) > 0:
+        cutout_name = '../pypsa-eur/cutouts/europe-' + str(weather_year) + '-' + cutout_source + '.nc'
+    else:
+        cutout_name = '../pypsa-eur/cutouts/europe-2013-era5.nc'
+
+    print(cutout_name)
+    cutout = atlite.Cutout(cutout_name)
+    # cutout = atlite.Cutout(snakemake.input.cutout)
 
     grid_cells = cutout.grid_cells()
 

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -26,11 +26,17 @@ if __name__ == '__main__':
 
     config = snakemake.config['solar_thermal']
 
-    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
-    
-    #cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
+    weather_year = snakemake.wildcards.weather_year
+    cutout_source = snakemake.config['cutout'].split('-')[1]
+
+    if len(weather_year) > 0:
+        time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-' + str(weather_year) + '-' + cutout_source + '.nc'
+    else:
+        time = pd.date_range('2013-01-01','2014-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-2013-era5.nc'
+
+    cutout = atlite.Cutout(cutout_name).sel(time=time)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_solar_thermal_profiles.py
+++ b/scripts/build_solar_thermal_profiles.py
@@ -26,9 +26,11 @@ if __name__ == '__main__':
 
     config = snakemake.config['solar_thermal']
 
-    time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(cutout_config).sel(time=time)
+    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
+    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+    
+    #cutout_config = snakemake.config['atlite']['cutout']
+    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -15,11 +15,17 @@ if __name__ == '__main__':
             clusters=48,
         )
 
-    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
-    
-    # cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
+    weather_year = snakemake.wildcards.weather_year
+    cutout_source = snakemake.config['cutout'].split('-')[1]
+
+    if len(weather_year) > 0:
+        time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-' + str(weather_year) + '-' + cutout_source + '.nc'
+    else:
+        time = pd.date_range('2013-01-01','2014-01-01',freq='h')[0:-1]
+        cutout_name = '../pypsa-eur/cutouts/europe-2013-era5.nc'
+
+    cutout = atlite.Cutout(cutout_name).sel(time=time)  
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/build_temperature_profiles.py
+++ b/scripts/build_temperature_profiles.py
@@ -15,9 +15,11 @@ if __name__ == '__main__':
             clusters=48,
         )
 
-    time = pd.date_range(freq='h', **snakemake.config['snapshots'])
-    cutout_config = snakemake.config['atlite']['cutout']
-    cutout = atlite.Cutout(cutout_config).sel(time=time)
+    # time = pd.date_range(freq='h', **snakemake.config['snapshots'])
+    time = pd.date_range(str(snakemake.wildcards.weather_year) + '-01-01',str(int(snakemake.wildcards.weather_year)+1) + '-01-01',freq='h')[0:-1]
+    
+    # cutout_config = snakemake.config['atlite']['cutout']
+    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=time)
 
     clustered_regions = gpd.read_file(
         snakemake.input.regions_onshore).set_index('name').buffer(0).squeeze()

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -699,7 +699,7 @@ if __name__ == "__main__":
             lv=1.5,
             opts='',
             sector_opts='Co2L0-168H-T-H-B-I-solar+p3-dist1',
-            planning_horizons=2030,
+            investment_year=2030,
         )
 
     overrides = override_component_attrs(snakemake.input.overrides)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -381,7 +381,7 @@ def plot_carbon_budget_distribution():
     ax1 = plt.subplot(gs1[0,0])
     ax1.set_ylabel('CO$_2$ emissions (Gt per year)',fontsize=22)
     ax1.set_ylim([0,5])
-    ax1.set_xlim([1990,snakemake.config['scenario']['planning_horizons'][-1]+1])
+    ax1.set_xlim([1990,snakemake.config['scenario']['investment_year'][-1]+1])
 
     path_cb = snakemake.config['results_dir'] + snakemake.config['run'] + '/csvs/'
     countries=pd.read_csv(path_cb + 'countries.csv',  index_col=1)
@@ -438,7 +438,7 @@ if __name__ == "__main__":
         from helper import mock_snakemake
         snakemake = mock_snakemake('plot_summary')
         
-    n_header = 4
+    n_header = 5
 
     plot_costs()
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -187,7 +187,7 @@ def build_carbon_budget(o, fn):
     #emissions at the beginning of the path (last year available 2018)
     e_0 = co2_emissions_year(countries, opts, year=2018)
 
-    planning_horizons = snakemake.config['scenario']['planning_horizons']
+    planning_horizons = snakemake.config['scenario']['investment_year']
     t_0 = planning_horizons[0]
 
     if "be" in o:
@@ -2413,7 +2413,7 @@ if __name__ == "__main__":
             clusters="37",
             lv=1.0,
             sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-            planning_horizons="2020",
+            investment_year="2020",
         )
 
     logging.basicConfig(level=snakemake.config['logging_level'])
@@ -2422,7 +2422,7 @@ if __name__ == "__main__":
 
     opts = snakemake.wildcards.sector_opts.split('-')
 
-    investment_year = int(snakemake.wildcards.planning_horizons[-4:])
+    investment_year = int(snakemake.wildcards.investment_year[-4:])
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -31,7 +31,7 @@ def _add_land_use_constraint(n):
 
     for carrier in ['solar', 'onwind', 'offwind-ac', 'offwind-dc']:
         existing = n.generators.loc[n.generators.carrier==carrier,"p_nom"].groupby(n.generators.bus.map(n.buses.location)).sum()
-        existing.index += " " + carrier + "-" + snakemake.wildcards.planning_horizons
+        existing.index += " " + carrier + "-" + snakemake.wildcards.investment_year
         n.generators.loc[existing.index,"p_nom_max"] -= existing
     
     n.generators.p_nom_max.clip(lower=0, inplace=True)
@@ -40,9 +40,9 @@ def _add_land_use_constraint(n):
 def _add_land_use_constraint_m(n):
     # if generators clustering is lower than network clustering, land_use accounting is at generators clusters
 
-    planning_horizons = snakemake.config["scenario"]["planning_horizons"] 
+    investment_years = snakemake.config["scenario"]["investment_year"] 
     grouping_years = snakemake.config["existing_capacities"]["grouping_years"]
-    current_horizon = snakemake.wildcards.planning_horizons
+    current_horizon = snakemake.wildcards.investment_year
 
     for carrier in ['solar', 'onwind', 'offwind-ac', 'offwind-dc']:
 
@@ -51,8 +51,8 @@ def _add_land_use_constraint_m(n):
         
         previous_years = [
             str(y) for y in 
-            planning_horizons + grouping_years
-            if y < int(snakemake.wildcards.planning_horizons)
+            investment_years + grouping_years
+            if y < int(snakemake.wildcards.investment_year)
         ]
 
         for p_year in previous_years:
@@ -280,8 +280,12 @@ if __name__ == "__main__":
             clusters=48,
             lv=1.0,
             sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
-            planning_horizons=2050,
+            investment_year=2050,
         )
+
+    print(snakemake.config['scenario']['weather_year'])
+    print(len(snakemake.config['scenario']['weather_year']))
+    print(len(snakemake.config['scenario']['weather_year'][0]))
 
     logging.basicConfig(filename=snakemake.log.python,
                         level=snakemake.config['logging_level'])


### PR DESCRIPTION
Related to the discussion in #177

## Changes proposed in this Pull Request

•	Weather year as wildcard {weather_year}
          o	Options to choose a weather year between 1979-2021
          o	The weather_year wildcard refers only to the datasets with direct weather dependence, i.e. renewable potential from wind and solar, and inflow for hydro, and e.g. year for historical electricity load, industry demand, etc., are not changed. Heat demand, solar thermal, and temperature profiles depend on weather data as well.
          o	**It is optional**. If not specified, it takes 2013 as weather year. 
          o	**Cutout is limited to ERA5** (I didn’t manage to retrieve Sarah for other years). However, some flexibility does exist if one should find a smart way to acquire sarah data (or other sources): Change config[‘cutout’] to e.g. ‘europe-sarah’ instead of ‘europe-era5’.
          o	**"snapshots" is substituted with config[‘loads’][‘year’]**. This might not be convenient if the optimization is based on a period of more than 1 year, i.e. perfect foresight for more than one year. An option could be to make configs[‘loads’][‘year’] a list of years or have it defined as a snapshot, as previously. The weather_year wildcard would then have to include two years, start and end year.

•	Investment year as wildcard {investment_year}
      o	The wildcard replaces {planning_horizons}
      o	For myopic optimization, {investment_year} acts as both the year of cost assumptions and as the year of planning
      o	For overnight optimization, {investment_year} only corresponds to the year of planning, where as config['cost']['year'] gives the year of cost cost assumptions

Things that I have not changed, but are no longer dependent on the “snapshots” which was earlier used to indicate period/year for data acquisition:
•	Electricity load year: 2013 (available from 2005 to 2018)  
•	Hydro production year: 2013 (available from 2000 to 2014)

Furthermore, the model relies on additional input years, which I have not altered:
•	Industry energy demand year: 2015 
•	Energy totals year: 2011
•	Eurostat report year 2016
•	Biomass: 2030

It might be convenient to argue why the different years have been selected.


## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `envs/environment.docs.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`, `config.tutorial.yaml`, and `test/config.test1.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.
