### PR TITLE
Fix snakemake dependencies in carbon budget runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ config.yaml
 doc/_build
 
 *.xls
+data/h2_salt_caverns_GWh_per_sqkm.geojson
+data/pypsa-eur-sec-data-bundle.tar.gz

--- a/Snakefile
+++ b/Snakefile
@@ -429,6 +429,8 @@ else:
 
 rule prepare_sector_network:
     input:
+        co2="data/eea/UNFCCC_v23.csv",
+        eurostat=input_eurostat,
         overrides="data/override_component_attrs",
         network=pypsaeur('networks/elec_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
         energy_totals_name='resources/energy_totals.csv',

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -143,16 +143,16 @@ def co2_emissions_year(countries, opts, year):
     Calculate CO2 emissions in one specific year (e.g. 1990 or 2018).
     """
 
-    eea_co2 = build_eea_co2(year)
+    eea_co2 = build_eea_co2(snakemake, year)
 
     # TODO: read Eurostat data from year > 2014
     # this only affects the estimation of CO2 emissions for BA, RS, AL, ME, MK
     if year > 2014:
-        eurostat_co2 = build_eurostat_co2(year=2014)
+        eurostat_co2 = build_eurostat_co2(snakemake, countries, year=2014)
     else:
-        eurostat_co2 = build_eurostat_co2(year)
+        eurostat_co2 = build_eurostat_co2(snakemake, countries, year)
 
-    co2_totals = build_co2_totals(eea_co2, eurostat_co2)
+    co2_totals = build_co2_totals(countries, eea_co2, eurostat_co2)
 
     sectors = emission_sectors_from_opts(opts)
 
@@ -2411,8 +2411,8 @@ if __name__ == "__main__":
             simpl='',
             opts="",
             clusters="37",
-            lv=1.0,
-            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            lv=1.5,
+            sector_opts='cb40ex0-2000H-T-H-B-I-A',
             planning_horizons="2020",
         )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -214,7 +214,7 @@ def build_carbon_budget(o, fn):
 
     # TODO log in Snakefile
     if not os.path.exists(fn):
-        os.makedirs(fn)
+        os.makedirs(os.path.dirname(fn))
     co2_cap.to_csv(fn, float_format='%.3f')
 
 


### PR DESCRIPTION
This PR should resolve issues when running the model with myopic foresight with a carbon budget defined by the 'cb' option. The main issue was that the Snakemake object was not passed to imported functions in prepare_sector_network.py.

The following steps have been done:
1. move the snakemake dependencies of the affected functions to
compulsory function arguments (in build_energy_totals.py)
2. enter snakemake object values in the function calls
(build_energy_totals and prepare_sector_network)
3. add the new explicit file dependencies to the Snakefile at rule
prepare_sector_network 

Following other errors have occured and should be resolved:
- The folder created for carbon_budget_distribution.csv included the csv file in the path itself when creating the folders, hence an error occured. Solved in commit 
78d1c92d2cb278f745930bc71bd7de3fe75fc6d4

- The functions build_eurostat_co2 and build_co2_totals from build_energy_totals were missing the 'countries' argument. Solved in commit 
e9e0f3f180fede40d7f20a807ce331c0c4ca75a2

- The function build_eurostat_co2 expects the country argument as pd.Index to run the line https://github.com/PyPSA/pypsa-eur-sec/commit/25638e3d107c5cb8ef5f2ed3ec428b226d984b43#diff-132a8f9b549899b7eee1fc97ad04baa7c72a349df45041ba0bc1266e58813cacR640 successfully. Solved in commit 25638e3d107c5cb8ef5f2ed3ec428b226d984b43

Remaining questions:
- Should the file dependencies to the Snakefile at rule
prepare_sector_network added optionally if 'cb' keyword is in
{sector_opts} wildcard)?
- When running the full snakemake workflow, an error in plot_summary occurs: It tries to read 'results/run_name/csvs/countries.csv' which does not exist. This is no file specified as output in the Snakefile. Where should the 'countries.csv' (originally) be created? 

Once the remaining questions are resolved, this PR could be transformed from Draft to ready. Coding improvements are highly welcome. Sorry for the long text ;)