### PR TITLE
copy_config: copy actual snakemake.config

### DIFF
--- a/scripts/copy_config.py
+++ b/scripts/copy_config.py
@@ -1,5 +1,6 @@
 
 from shutil import copy
+import yaml
 
 files = {
     "config.yaml": "config.yaml",
@@ -14,5 +15,16 @@ if __name__ == '__main__':
         from helper import mock_snakemake
         snakemake = mock_snakemake('copy_config')
 
+    basepath = snakemake.config['summary_dir'] + '/' + snakemake.config['run'] + '/configs/'
+
     for f, name in files.items():
-        copy(f,snakemake.config['summary_dir'] + '/' + snakemake.config['run'] + '/configs/' + name)
+        copy(f, basepath + name)
+
+    with open(basepath + 'config.snakemake.yaml', 'w') as yaml_file:
+        yaml.dump(
+            snakemake.config,
+            yaml_file,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False
+        )


### PR DESCRIPTION
Just copying `config.yaml` is not correct, depending on how `snakemake` is called.

Example:

```sh
snakemake --configfile config.scenarioA.yaml ....
```
Would overwrite parts of `config.yaml`.