### PR TITLE
fix grouping years list issue caused by newer powerplant database

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -134,7 +134,7 @@ solar_thermal:
 
 # only relevant for foresight = myopic or perfect
 existing_capacities:
-  grouping_years: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019]
+  grouping_years: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
   threshold_capacity: 10
   conventional_carriers:
     - lignite


### PR DESCRIPTION
the default set of vintage classes specified in config.default.yaml does not account for the new powerplant database with powerplants built until 2027. This causes an error that is hard to spot :(
increasing the upper range of the list solves the problem.