### PR TITLE
Document units of bus carriers

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,7 +24,7 @@ incorporates retrofitting options to hydrogen.
 * New rule ``build_gas_input_locations`` compiles the LNG import capacities
   (including planned projects from gem.wiki), pipeline entry capacities and
   local production capacities for each region of the model. These are the
-  regions where fossil gas can eventually enter the model. 
+  regions where fossil gas can eventually enter the model.
 
 * New rule ``cluster_gas_network`` that clusters the gas transmission network
   data to the model resolution. Cross-regional pipeline capacities are aggregated
@@ -47,14 +47,16 @@ incorporates retrofitting options to hydrogen.
   H2_retrofit_capacity_per_CH4`` units are made available as hydrogen pipeline
   capacity in the corresponding corridor. These repurposed hydrogen pipelines
   have lower costs than new hydrogen pipelines. Both new and repurposed pipelines
-  can be built simultaneously. The retrofitting option ``sector: H2_retrofit:`` also works 
-  with a copperplated methane infrastructure, i.e. when ``sector: gas_network: false``. 
+  can be built simultaneously. The retrofitting option ``sector: H2_retrofit:`` also works
+  with a copperplated methane infrastructure, i.e. when ``sector: gas_network: false``.
 
 * New hydrogen pipelines can now be built where there are already power or gas
   transmission routes. Previously, only the electricity transmission routes were
   considered.
 
 **New features and functionality**
+
+* Units are assigned to the buses. These only provide a better understanding. The specifications of the units are not taken into account in the optimisation, which means that no automatic conversion of units takes place.
 
 * Option ``retrieve_sector_databundle`` to automatically retrieve and extract data bundle.
 
@@ -84,7 +86,7 @@ besides many performance improvements.
 
 This release is known to work with `PyPSA-Eur
 <https://github.com/PyPSA/pypsa-eur>`_ Version 0.4.0, `Technology Data
-<https://github.com/PyPSA/technology-data>`_ Version 0.3.0 and 
+<https://github.com/PyPSA/technology-data>`_ Version 0.3.0 and
 `PyPSA <https://github.com/PyPSA/PyPSA>`_ Version 0.18.0.
 
 Please note that the data bundle has also been updated.
@@ -202,19 +204,19 @@ Please note that the data bundle has also been updated.
   A function ``helper.override_component_attrs`` was added that loads this data
   and can pass the overridden component attributes into ``pypsa.Network()``.
 
-* Add various parameters to ``config.default.yaml`` which were previously hardcoded inside the scripts 
+* Add various parameters to ``config.default.yaml`` which were previously hardcoded inside the scripts
   (e.g. energy reference years, BEV settings, solar thermal collector models, geomap colours).
 
 * Removed stale industry demand rules ``build_industrial_energy_demand_per_country``
   and ``build_industrial_demand``. These are superseded with more regionally resolved rules.
 
 * Use simpler and shorter ``gdf.sjoin()`` function to allocate industrial sites
-  from the Hotmaps database to onshore regions.  
+  from the Hotmaps database to onshore regions.
   This change also fixes a bug:
   The previous version allocated sites to the closest bus,
   but at country borders (where Voronoi cells are distorted by the borders),
   this had resulted in e.g. a Spanish site close to the French border
-  being wrongly allocated to the French bus if the bus center was closer. 
+  being wrongly allocated to the French bus if the bus center was closer.
 
 * Retrofitting rule is now only triggered if endogeneously optimised.
 
@@ -225,7 +227,7 @@ Please note that the data bundle has also been updated.
 * Improve legibility of ``config.default.yaml`` and remove unused options.
 
 * Use the country-specific time zone mappings from ``pytz`` rather than a manual mapping.
-  
+
 * A function ``add_carrier_buses()`` was added to the ``prepare_network`` rule to reduce code duplication.
 
 * In the ``prepare_network`` rule the cost and potential adjustment was moved into an

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -388,7 +388,8 @@ def add_carrier_buses(n, carrier, nodes=None):
     n.madd("Bus",
         nodes,
         location=location,
-        carrier=carrier
+        carrier=carrier,
+        unit='MWh_th'
     )
 
     #capital cost could be corrected to e.g. 0.2 EUR/kWh * annuity and O&M
@@ -439,6 +440,7 @@ def patch_electricity_network(n):
     update_wind_solar_costs(n, costs)
     n.loads["carrier"] = "electricity"
     n.buses["location"] = n.buses.index
+    n.buses["unit"] = "MWh_el"
     # remove trailing white space of load index until new PyPSA version after v0.18.
     n.loads.rename(lambda x: x.strip(), inplace=True)
     n.loads_t.p_set.rename(lambda x: x.strip(), axis=1, inplace=True)
@@ -455,7 +457,8 @@ def add_co2_tracking(n, options):
     n.add("Bus",
         "co2 atmosphere",
         location="EU",
-        carrier="co2"
+        carrier="co2",
+        unit="t_co2"
     )
 
     # can also be negative
@@ -471,7 +474,8 @@ def add_co2_tracking(n, options):
     n.madd("Bus",
         spatial.co2.nodes,
         location=spatial.co2.locations,
-        carrier="co2 stored"
+        carrier="co2 stored",
+        unit="t_co2"
     )
 
     n.madd("Store",
@@ -703,7 +707,8 @@ def insert_electricity_distribution_grid(n, costs):
     n.madd("Bus",
         nodes + " low voltage",
         location=nodes,
-        carrier="low voltage"
+        carrier="low voltage",
+        unit="MWh_el"
     )
 
     n.madd("Link",
@@ -770,7 +775,8 @@ def insert_electricity_distribution_grid(n, costs):
     n.madd("Bus",
         nodes + " home battery",
         location=nodes,
-        carrier="home battery"
+        carrier="home battery",
+        unit="MWh_el"
     )
 
     n.madd("Store",
@@ -845,7 +851,8 @@ def add_storage_and_grids(n, costs):
     n.madd("Bus",
         nodes + " H2",
         location=nodes,
-        carrier="H2"
+        carrier="H2",
+        unit="MWh_LHV"
     )
 
     n.madd("Link",
@@ -1051,7 +1058,8 @@ def add_storage_and_grids(n, costs):
     n.madd("Bus",
         nodes + " battery",
         location=nodes,
-        carrier="battery"
+        carrier="battery",
+        unit="MWh_el"
     )
 
     n.madd("Store",
@@ -1199,7 +1207,8 @@ def add_land_transport(n, costs):
             nodes,
             location=nodes,
             suffix=" EV battery",
-            carrier="Li ion"
+            carrier="Li ion",
+            unit="MWh_el"
         )
 
         p_set = electric_share * (transport[nodes] + cycling_shift(transport[nodes], 1) + cycling_shift(transport[nodes], 2)) / 3
@@ -1273,7 +1282,8 @@ def add_land_transport(n, costs):
             n.madd("Bus",
                 spatial.oil.nodes,
                 location=spatial.oil.locations,
-                carrier="oil"
+                carrier="oil",
+                unit="MWh_th"
             )
 
         ice_efficiency = options['transport_internal_combustion_efficiency']
@@ -1381,7 +1391,8 @@ def add_heat(n, costs):
         n.madd("Bus",
             nodes[name] + f" {name} heat",
             location=nodes[name],
-            carrier=name + " heat"
+            carrier=name + " heat",
+            unit="MWh_th"
         )
 
         ## Add heat load
@@ -1438,7 +1449,8 @@ def add_heat(n, costs):
             n.madd("Bus",
                 nodes[name] + f" {name} water tanks",
                 location=nodes[name],
-                carrier=name + " water tanks"
+                carrier=name + " water tanks",
+                unit="MWh_th"
             )
 
             n.madd("Link",
@@ -1743,13 +1755,15 @@ def add_biomass(n, costs):
     n.madd("Bus",
         spatial.gas.biogas,
         location=spatial.gas.locations,
-        carrier="biogas"
+        carrier="biogas",
+        unit="MWh_th"
     )
 
     n.madd("Bus",
         spatial.biomass.nodes,
         location=spatial.biomass.locations,
-        carrier="solid biomass"
+        carrier="solid biomass",
+        unit="MWh_th"
     )
 
     n.madd("Store",
@@ -1860,7 +1874,8 @@ def add_industry(n, costs):
     n.madd("Bus",
         spatial.biomass.industry,
         location=spatial.biomass.locations,
-        carrier="solid biomass for industry"
+        carrier="solid biomass for industry",
+        unit="MWh_th"
     )
 
     if options["biomass_transport"]:
@@ -1902,7 +1917,8 @@ def add_industry(n, costs):
     n.madd("Bus",
         spatial.gas.industry,
         location=spatial.gas.locations,
-        carrier="gas for industry")
+        carrier="gas for industry",
+        unit="MWh_LHV")
 
     gas_demand = industrial_demand.loc[nodes, "methane"] / 8760.
 
@@ -1958,7 +1974,8 @@ def add_industry(n, costs):
             nodes,
             suffix=" H2 liquid",
             carrier="H2 liquid",
-            location=nodes
+            location=nodes,
+            unit="MWh_LHV"
         )
 
         n.madd("Link",
@@ -2016,7 +2033,8 @@ def add_industry(n, costs):
         n.madd("Bus",
             spatial.oil.nodes,
             location=spatial.oil.locations,
-            carrier="oil"
+            carrier="oil",
+            unit="MWh_th"
         )
 
     if "oil" not in n.stores.carrier.unique():
@@ -2130,7 +2148,8 @@ def add_industry(n, costs):
     n.add("Bus",
         "process emissions",
         location="EU",
-        carrier="process emissions"
+        carrier="process emissions",
+        unit="t_co2"
     )
 
     # this should be process emissions fossil+feedstock
@@ -2314,7 +2333,7 @@ if __name__ == "__main__":
             simpl='',
             opts="",
             clusters="37",
-            lv=1.0,
+            lv=1.5,
             sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
             planning_horizons="2020",
         )
@@ -2448,3 +2467,5 @@ if __name__ == "__main__":
         add_electricity_grid_connection(n, costs)
 
     n.export_to_netcdf(snakemake.output[0])
+
+# %%

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -385,11 +385,13 @@ def add_carrier_buses(n, carrier, nodes=None):
 
     n.add("Carrier", carrier)
 
+    unit="MWh_LHV" if carrier=="gas" else "MWH_th"
+
     n.madd("Bus",
         nodes,
         location=location,
         carrier=carrier,
-        unit='MWh_th'
+        unit=unit
     )
 
     #capital cost could be corrected to e.g. 0.2 EUR/kWh * annuity and O&M

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1285,7 +1285,7 @@ def add_land_transport(n, costs):
                 spatial.oil.nodes,
                 location=spatial.oil.locations,
                 carrier="oil",
-                unit="MWh_th"
+                unit="MWh_LHV"
             )
 
         ice_efficiency = options['transport_internal_combustion_efficiency']
@@ -1758,14 +1758,14 @@ def add_biomass(n, costs):
         spatial.gas.biogas,
         location=spatial.gas.locations,
         carrier="biogas",
-        unit="MWh_th"
+        unit="MWh_LHV"
     )
 
     n.madd("Bus",
         spatial.biomass.nodes,
         location=spatial.biomass.locations,
         carrier="solid biomass",
-        unit="MWh_th"
+        unit="MWh_LHV"
     )
 
     n.madd("Store",
@@ -1877,7 +1877,7 @@ def add_industry(n, costs):
         spatial.biomass.industry,
         location=spatial.biomass.locations,
         carrier="solid biomass for industry",
-        unit="MWh_th"
+        unit="MWh_LHV"
     )
 
     if options["biomass_transport"]:
@@ -2036,7 +2036,7 @@ def add_industry(n, costs):
             spatial.oil.nodes,
             location=spatial.oil.locations,
             carrier="oil",
-            unit="MWh_th"
+            unit="MWh_LHV"
         )
 
     if "oil" not in n.stores.carrier.unique():

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -385,7 +385,7 @@ def add_carrier_buses(n, carrier, nodes=None):
 
     n.add("Carrier", carrier)
 
-    unit="MWh_LHV" if carrier=="gas" else "MWH_th"
+    unit = "MWh_LHV" if carrier == "gas" else "MWh_th"
 
     n.madd("Bus",
         nodes,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2469,5 +2469,3 @@ if __name__ == "__main__":
         add_electricity_grid_connection(n, costs)
 
     n.export_to_netcdf(snakemake.output[0])
-
-# %%


### PR DESCRIPTION
add explicit documentation of the unit of each bus' carrier
this addresses the issue https://github.com/PyPSA/pypsa-eur-sec/issues/134#event-6804897616

Bus [unit]:

- electricity, low voltage [MWh_el]
- home battery, battery, batteries in transport  [MWh_el]

- coal, nuclear and oil  [MWh_th]
- ice in transport [MWh_th]
- buses in heat sector [MWh_th]
- biogas and biomas [MWh_th]

- co2 atmosphere, co2 stored, process emissions [t_co2]

- H2, shipping_hydrogen_liquefaction [MWh_LHV]
- gas for industry [MWh_LHV]
