### PR TITLE
build_biomass_potentials: fix pandas error

### DIFF
--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -183,7 +183,7 @@ def convert_nuts2_to_regions(bio_nuts2, regions):
     overlay["share"] = area(overlay) / overlay["area_nuts2"]
 
     # multiply all nuts2-level values with share of nuts2 inside region
-    adjust_cols = overlay.columns.difference({"name", "area_nuts2", "geometry", "share"})
+    adjust_cols = overlay.columns.difference({"name", "area_nuts2", "geometry", "share", "country"})
     overlay[adjust_cols] = overlay[adjust_cols].multiply(overlay["share"], axis=0)
 
     bio_regions = overlay.groupby("name").sum()


### PR DESCRIPTION
When running the build_biomass_potentials script, I got the pandas error in the convert_nuts2_to_regions method that you cannot multiply a sequence with non-numerical entries. Apparently, the regions now have a column called countries, which is not filtered out before multiplying and causes the error. In this PR the country column is excluded for the multiplication.