### PR TITLE
option to specify any config through sector opts with CF:<label>:<value>

### DIFF
--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -11,7 +11,7 @@ import yaml
 import numpy as np
 
 from add_existing_baseyear import add_build_year_to_new_assets
-from helper import override_component_attrs
+from helper import override_component_attrs, update_config_with_sector_opts
 from solve_network import basename
 
 
@@ -122,6 +122,8 @@ if __name__ == "__main__":
             sector_opts='168H-T-H-B-I-solar+p3-dist1',
             planning_horizons=2030,
         )
+
+    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
     print(snakemake.input.network_p)
     logging.basicConfig(level=snakemake.config['logging_level'])

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -13,7 +13,7 @@ import pypsa
 import yaml
 
 from prepare_sector_network import prepare_costs, define_spatial
-from helper import override_component_attrs
+from helper import override_component_attrs, update_config_with_sector_opts
 
 from types import SimpleNamespace
 spatial = SimpleNamespace()
@@ -462,6 +462,8 @@ if __name__ == "__main__":
         )
 
     logging.basicConfig(level=snakemake.config['logging_level'])
+
+    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
     options = snakemake.config["sector"]
     opts = snakemake.wildcards.sector_opts.split('-')

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -1,7 +1,9 @@
 import os
+import yaml
 import pytz
 import pandas as pd
 from pathlib import Path
+from mergedeep import merge
 from pypsa.descriptors import Dict
 from pypsa.components import components, component_attrs
 
@@ -125,3 +127,17 @@ def generate_periodic_profiles(dt_index, nodes, weekly_profile, localize=None):
     week_df = week_df.tz_localize(localize)
 
     return week_df
+
+
+def parse(l):
+    if len(l) == 1:
+        return yaml.safe_load(l[0])
+    else:
+        return {l.pop(0): parse(l)}
+
+
+def update_config_with_sector_opts(config, sector_opts):
+    for o in sector_opts.split("-"):
+        if o.startswith("CF:"):
+            l = o.split(":")[1:]
+            merge(config, parse(l))

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -3,7 +3,7 @@ import yaml
 import pytz
 import pandas as pd
 from pathlib import Path
-from mergedeep import merge
+from snakemake.utils import update_config
 from pypsa.descriptors import Dict
 from pypsa.components import components, component_attrs
 
@@ -140,4 +140,4 @@ def update_config_with_sector_opts(config, sector_opts):
     for o in sector_opts.split("-"):
         if o.startswith("CF:"):
             l = o.split(":")[1:]
-            merge(config, parse(l))
+            update_config(config, parse(l))

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -139,5 +139,5 @@ def parse(l):
 def update_config_with_sector_opts(config, sector_opts):
     for o in sector_opts.split("-"):
         if o.startswith("CF:"):
-            l = o.split(":")[1:]
+            l = o.split("+")[1:]
             update_config(config, parse(l))

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from prepare_sector_network import co2_emissions_year
+from helper import update_config_with_sector_opts
 
 #consolidate and rename
 def rename_techs(label):
@@ -437,7 +438,9 @@ if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
         snakemake = mock_snakemake('plot_summary')
-        
+    
+    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
+
     n_header = 4
 
     plot_costs()

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -14,7 +14,7 @@ from scipy.stats import beta
 from vresutils.costdata import annuity
 
 from build_energy_totals import build_eea_co2, build_eurostat_co2, build_co2_totals
-from helper import override_component_attrs, generate_periodic_profiles
+from helper import override_component_attrs, generate_periodic_profiles, update_config_with_sector_opts
 
 from networkx.algorithms.connectivity.edge_augmentation import k_edge_augmentation
 from networkx.algorithms import complement
@@ -2338,6 +2338,8 @@ if __name__ == "__main__":
         )
 
     logging.basicConfig(level=snakemake.config['logging_level'])
+
+    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
     options = snakemake.config["sector"]
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -11,7 +11,7 @@ from pypsa.linopf import network_lopf, ilopf
 
 from vresutils.benchmark import memory_logger
 
-from helper import override_component_attrs
+from helper import override_component_attrs, update_config_with_sector_opts
 
 import logging
 logger = logging.getLogger(__name__)
@@ -289,6 +289,8 @@ if __name__ == "__main__":
 
     logging.basicConfig(filename=snakemake.log.python,
                         level=snakemake.config['logging_level'])
+
+    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
 
     tmpdir = snakemake.config['solving'].get('tmpdir')
     if tmpdir is not None:


### PR DESCRIPTION
This PR generalises tweaking config parameters through the `{sector_opts}` wildcard. Closes #244.

For example `CF+sector+district_heating+potential+0.8` or `CF+sector+v2g+false` will overwrite `snakemake.config` with the following:

```yaml
sector:
  district_heating:
    potential: 0.8
  v2g: false
```

The routine is triggered by a `CF+`. Then you can pipe to any config setting. Just be aware that this will only have an effect on rules with the `{sector_opts}` wildcard.

- Uses `snakemake.utils.update_config`
- This will work even better with #250 because then the update of `snakemake.config` in each rule can be skipped.