### PR TITLE
Fix bug myopic co2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -571,7 +571,8 @@ rule plot_summary:
         costs=SDIR + '/csvs/costs.csv',
         energy=SDIR + '/csvs/energy.csv',
         balances=SDIR + '/csvs/supply_energy.csv',
-        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
+        eurostat=input_eurostat,
+        country_codes='data/Country_codes.csv',
     output:
         costs=SDIR + '/graphs/costs.pdf',
         energy=SDIR + '/graphs/energy.pdf',

--- a/Snakefile
+++ b/Snakefile
@@ -442,14 +442,14 @@ rule build_population_weighted_energy_totals:
 
 
 rule build_transport_demand:
-    input: 
+    input:
         clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
         pop_weighted_energy_totals="resources/pop_weighted_energy_totals_s{simpl}_{clusters}.csv",
         transport_data='resources/transport_data.csv',
         traffic_data_KFZ="data/emobility/KFZ__count",
         traffic_data_Pkw="data/emobility/Pkw__count",
         temp_air_total="resources/temp_air_total_elec_s{simpl}_{clusters}.nc",
-    output: 
+    output:
         transport_demand="resources/transport_demand_s{simpl}_{clusters}.csv",
         transport_data="resources/transport_data_s{simpl}_{clusters}.csv",
         avail_profile="resources/avail_profile_s{simpl}_{clusters}.csv",
@@ -464,12 +464,14 @@ rule prepare_sector_network:
         overrides="data/override_component_attrs",
         network=pypsaeur('networks/elec_s{simpl}_{clusters}_ec_lv{lv}_{opts}.nc'),
         energy_totals_name='resources/energy_totals.csv',
+        eurostat=input_eurostat,
         pop_weighted_energy_totals="resources/pop_weighted_energy_totals_s{simpl}_{clusters}.csv",
         transport_demand="resources/transport_demand_s{simpl}_{clusters}.csv",
         transport_data="resources/transport_data_s{simpl}_{clusters}.csv",
         avail_profile="resources/avail_profile_s{simpl}_{clusters}.csv",
         dsm_profile="resources/dsm_profile_s{simpl}_{clusters}.csv",
         co2_totals_name='resources/co2_totals.csv',
+        co2="data/eea/UNFCCC_v23.csv",
         biomass_potentials='resources/biomass_potentials_s{simpl}_{clusters}.csv',
         heat_profile="data/heat_load_profile_BDEW.csv",
         costs=CDIR + "costs_{planning_horizons}.csv",
@@ -568,7 +570,8 @@ rule plot_summary:
     input:
         costs=SDIR + '/csvs/costs.csv',
         energy=SDIR + '/csvs/energy.csv',
-        balances=SDIR + '/csvs/supply_energy.csv'
+        balances=SDIR + '/csvs/supply_energy.csv',
+        clustered_pop_layout="resources/pop_layout_elec_s{simpl}_{clusters}.csv",
     output:
         costs=SDIR + '/graphs/costs.pdf',
         energy=SDIR + '/graphs/energy.pdf',

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -134,7 +134,8 @@ solar_thermal:
 
 # only relevant for foresight = myopic or perfect
 existing_capacities:
-  grouping_years: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_power: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # these should not extend 2020
   threshold_capacity: 10
   conventional_carriers:
     - lignite

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -42,7 +42,12 @@ scenario:
   # decay with initial growth rate 0
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
     - 2030
-  # for example, set to [2020, 2030, 2040, 2050] for myopic foresight
+  # for example, set to
+  # - 2020
+  # - 2030
+  # - 2040
+  # - 2050
+  # for myopic foresight
 
 # CO2 budget as a fraction of 1990 emissions
 # this is over-ridden if CO2Lx is set in sector_opts

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -294,7 +294,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
                 )
 
 
-def add_heating_capacities_installed_before_baseyear(n, baseyear, ashp_cop, gshp_cop, time_dep_hp_cop, costs, default_lifetime):
+def add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years, ashp_cop, gshp_cop, time_dep_hp_cop, costs, default_lifetime):
     """
     Parameters
     ----------
@@ -314,7 +314,7 @@ def add_heating_capacities_installed_before_baseyear(n, baseyear, ashp_cop, gshp
     # https://ec.europa.eu/energy/studies/mapping-and-analyses-current-and-future-2020-2030-heatingcooling-fuel-deployment_en?redir=1
     # file: "WP2_DataAnnex_1_BuildingTechs_ForPublication_201603.xls" -> "existing_heating_raw.csv".
     # TODO start from original file
-    grouping_years = [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019]
+
     # retrieve existing heating capacities
     techs = [
         'gas boiler',
@@ -505,14 +505,16 @@ if __name__ == "__main__":
         snakemake.config['costs']['lifetime']
     )
 
-    grouping_years = snakemake.config['existing_capacities']['grouping_years']
-    add_power_capacities_installed_before_baseyear(n, grouping_years, costs, baseyear)
+    grouping_years_power = snakemake.config['existing_capacities']['grouping_years_power']
+    grouping_years_heat = snakemake.config['existing_capacities']['grouping_years_heat']
+    add_power_capacities_installed_before_baseyear(n, grouping_years_power, costs, baseyear)
 
     if "H" in opts:
         time_dep_hp_cop = options["time_dep_hp_cop"]
         ashp_cop = xr.open_dataarray(snakemake.input.cop_air_total).to_pandas().reindex(index=n.snapshots)
         gshp_cop = xr.open_dataarray(snakemake.input.cop_soil_total).to_pandas().reindex(index=n.snapshots)
         default_lifetime = snakemake.config['costs']['lifetime']
-        add_heating_capacities_installed_before_baseyear(n, baseyear, ashp_cop, gshp_cop, time_dep_hp_cop, costs, default_lifetime)
+        add_heating_capacities_installed_before_baseyear(n, baseyear, grouping_years_heat,
+                                                         ashp_cop, gshp_cop, time_dep_hp_cop, costs, default_lifetime)
 
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -131,7 +131,8 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         'Oil': 'oil',
         'OCGT': 'OCGT',
         'CCGT': 'CCGT',
-        'Natural Gas': 'gas'
+        'Natural Gas': 'gas',
+        'Bioenergy': 'urban central solid biomass CHP',
     }
 
     fueltype_to_drop = [
@@ -139,7 +140,6 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         'Wind',
         'Solar',
         'Geothermal',
-        'Bioenergy',
         'Waste',
         'Other',
         'CCGT, Thermal'
@@ -150,6 +150,11 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
         'Storage Technologies'
     ]
 
+    # drop assets which are already phased out / decomissioned
+    phased_out = df_agg[df_agg["DateOut"]<baseyear].index
+    df_agg.drop(phased_out, inplace=True)
+    # calculate remaining lifetime before phase-out
+    df_agg["lifetime"] = df_agg.DateOut-baseyear
     df_agg.drop(df_agg.index[df_agg.Fueltype.isin(fueltype_to_drop)], inplace=True)
     df_agg.drop(df_agg.index[df_agg.Technology.isin(technology_to_drop)], inplace=True)
     df_agg.Fueltype = df_agg.Fueltype.map(rename_fuel)
@@ -477,7 +482,7 @@ if __name__ == "__main__":
             clusters="45",
             lv=1.0,
             opts='',
-            sector_opts='cb40ex0-365H-T-H-B-I-A-solar+p3-dist1',
+            sector_opts='365H-T-H-B-I-A-solar+p3-dist1',
             planning_horizons=2020,
         )
 
@@ -488,7 +493,7 @@ if __name__ == "__main__":
     options = snakemake.config["sector"]
     opts = snakemake.wildcards.sector_opts.split('-')
 
-    baseyear= snakemake.config['scenario']["planning_horizons"][0]
+    baseyear = snakemake.config['scenario']["planning_horizons"][0]
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -385,9 +385,8 @@ def plot_carbon_budget_distribution(input_eurostat):
     ax1.set_xlim([1990,snakemake.config['scenario']['planning_horizons'][-1]+1])
 
     path_cb = snakemake.config['results_dir'] + snakemake.config['run'] + '/csvs/'
-    pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
-    countries=pd.read_csv(snakemake.input.country_codes, index_col=1)
-    cts=countries.index.to_list()
+    countries = pd.read_csv(snakemake.input.country_codes, index_col=1)
+    cts = countries.index.to_list()
     e_1990 = co2_emissions_year(cts, input_eurostat, opts, year=1990)
     CO2_CAP=pd.read_csv(path_cb + 'carbon_budget_distribution.csv',
                         index_col=0)

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -202,7 +202,7 @@ def plot_energy():
     new_index = preferred_order.intersection(df.index).append(df.index.difference(preferred_order))
 
     new_columns = df.columns.sort_values()
-    
+
     fig, ax = plt.subplots(figsize=(12,8))
 
     print(df.loc[new_index, new_columns])
@@ -363,7 +363,7 @@ def historical_emissions(cts):
 
 
 
-def plot_carbon_budget_distribution():
+def plot_carbon_budget_distribution(input_eurostat):
     """
     Plot historical carbon emissions in the EU and decarbonization path
     """
@@ -385,9 +385,10 @@ def plot_carbon_budget_distribution():
     ax1.set_xlim([1990,snakemake.config['scenario']['planning_horizons'][-1]+1])
 
     path_cb = snakemake.config['results_dir'] + snakemake.config['run'] + '/csvs/'
-    countries=pd.read_csv(path_cb + 'countries.csv',  index_col=1)
+    pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
+    countries=pd.read_csv(snakemake.input.country_codes, index_col=1)
     cts=countries.index.to_list()
-    e_1990 = co2_emissions_year(cts, opts, year=1990)
+    e_1990 = co2_emissions_year(cts, input_eurostat, opts, year=1990)
     CO2_CAP=pd.read_csv(path_cb + 'carbon_budget_distribution.csv',
                         index_col=0)
 
@@ -438,8 +439,7 @@ if __name__ == "__main__":
     if 'snakemake' not in globals():
         from helper import mock_snakemake
         snakemake = mock_snakemake('plot_summary')
-    
-    update_config_with_sector_opts(snakemake.config, snakemake.wildcards.sector_opts)
+
 
     n_header = 4
 
@@ -453,4 +453,4 @@ if __name__ == "__main__":
         opts=sector_opts.split('-')
         for o in opts:
             if "cb" in o:
-                plot_carbon_budget_distribution()
+                plot_carbon_budget_distribution(snakemake.input.eurostat)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -158,21 +158,24 @@ def get(item, investment_year=None):
         return item
 
 
-def co2_emissions_year(countries, opts, year):
+def co2_emissions_year(opts, year):
     """
     Calculate CO2 emissions in one specific year (e.g. 1990 or 2018).
     """
-
-    eea_co2 = build_eea_co2(year)
+    emissions_scope = snakemake.config["energy"]["emissions"]
+    eea_co2 = build_eea_co2(snakemake.input.co2, year, emissions_scope)
+    input_eurostat = snakemake.input.eurostat
 
     # TODO: read Eurostat data from year > 2014
     # this only affects the estimation of CO2 emissions for BA, RS, AL, ME, MK
+    report_year = snakemake.config["energy"]["eurostat_report_year"]
+    countries =  pd.Index(pop_layout.ct.unique())
     if year > 2014:
-        eurostat_co2 = build_eurostat_co2(year=2014)
+        eurostat_co2 = build_eurostat_co2(input_eurostat, countries, report_year, year=2014)
     else:
-        eurostat_co2 = build_eurostat_co2(year)
+        eurostat_co2 = build_eurostat_co2(input_eurostat, countries, report_year, year)
 
-    co2_totals = build_co2_totals(eea_co2, eurostat_co2)
+    co2_totals = build_co2_totals(countries, eea_co2, eurostat_co2)
 
     sectors = emission_sectors_from_opts(opts)
 
@@ -202,10 +205,10 @@ def build_carbon_budget(o, fn):
 
     countries = n.buses.country.dropna().unique()
 
-    e_1990 = co2_emissions_year(countries, opts, year=1990)
+    e_1990 = co2_emissions_year( opts, year=1990)
 
     #emissions at the beginning of the path (last year available 2018)
-    e_0 = co2_emissions_year(countries, opts, year=2018)
+    e_0 = co2_emissions_year(opts, year=2018)
 
     planning_horizons = snakemake.config['scenario']['planning_horizons']
     t_0 = planning_horizons[0]
@@ -233,8 +236,9 @@ def build_carbon_budget(o, fn):
         co2_cap = pd.Series({t: exponential_decay(t) for t in planning_horizons}, name=o)
 
     # TODO log in Snakefile
-    if not os.path.exists(fn):
-        os.makedirs(fn)
+    csvs_folder = fn.rsplit("/", 1)[0]
+    if not os.path.exists(csvs_folder):
+        os.makedirs(csvs_folder)
     co2_cap.to_csv(fn, float_format='%.3f')
 
 
@@ -2333,7 +2337,7 @@ if __name__ == "__main__":
             opts="",
             clusters="37",
             lv=1.5,
-            sector_opts='Co2L0-168H-T-H-B-I-solar3-dist1',
+            sector_opts='cb40ex0-365H-T-H-B-I-A-solar+p3-dist1',
             planning_horizons="2020",
         )
 
@@ -2439,7 +2443,7 @@ if __name__ == "__main__":
         if not os.path.exists(fn):
             build_carbon_budget(o, fn)
         co2_cap = pd.read_csv(fn, index_col=0).squeeze()
-        limit = co2_cap[investment_year]
+        limit = co2_cap.loc[investment_year]
         break
     for o in opts:
         if not "Co2L" in o: continue

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -158,18 +158,16 @@ def get(item, investment_year=None):
         return item
 
 
-def co2_emissions_year(opts, year):
+def co2_emissions_year(countries, input_eurostat, opts, year):
     """
     Calculate CO2 emissions in one specific year (e.g. 1990 or 2018).
     """
     emissions_scope = snakemake.config["energy"]["emissions"]
     eea_co2 = build_eea_co2(snakemake.input.co2, year, emissions_scope)
-    input_eurostat = snakemake.input.eurostat
 
     # TODO: read Eurostat data from year > 2014
     # this only affects the estimation of CO2 emissions for BA, RS, AL, ME, MK
     report_year = snakemake.config["energy"]["eurostat_report_year"]
-    countries =  pd.Index(pop_layout.ct.unique())
     if year > 2014:
         eurostat_co2 = build_eurostat_co2(input_eurostat, countries, report_year, year=2014)
     else:
@@ -205,10 +203,10 @@ def build_carbon_budget(o, fn):
 
     countries = n.buses.country.dropna().unique()
 
-    e_1990 = co2_emissions_year( opts, year=1990)
+    e_1990 = co2_emissions_year(countries, snakemake.input.eurostat, opts, year=1990)
 
     #emissions at the beginning of the path (last year available 2018)
-    e_0 = co2_emissions_year(opts, year=2018)
+    e_0 = co2_emissions_year(countries, snakemake.input.eurostat, opts, year=2018)
 
     planning_horizons = snakemake.config['scenario']['planning_horizons']
     t_0 = planning_horizons[0]


### PR DESCRIPTION
This PR should fix three bugs 

1. the option to limit the CO2 emissions by e.g. `cb40ex0` as a sector_opts was not working anymore due to changes in the `build_energy_totals.py script`
2. by changing the` grouping_years` in this PR here #240 to `[1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025, 2030]` two issues arise in the `add_existing_baseyear.py `script: 
- components with same names where added to the network (e.g. for planning horizon 2020 existing infrastructure for solar was added with the same name as the extendable assets for this planning horizon)
- the existing heating infrastructure data is not taken from the powerplant matching and should be  therefore evenly distributed over the last 25 years (old grouping_years, not including future years 2025 and 2030)
3. fixes in plot_summary for myopic code and also removing update_config_with_sector_opts introduced in #251 since sector opts is not a wildcard for this rule