### PR TITLE
update sector opt for co2 seq potential

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -33,7 +33,7 @@ scenario:
   # A for agriculture, forestry and fishing
   # solar+c0.5 reduces the capital cost of solar to 50\% of reference value
   # solar+p3 multiplies the available installable potential by factor 3
-  # co2 stored+e2 multiplies the potential of CO2 sequestration by a factor 2
+  # seq2 (or e.g. seq0p5) multiplies the potential of CO2 sequestration by a factor 2 (or e.g. 0.5)
   # dist{n} includes distribution grids with investment cost of n times cost in data/costs.csv
   # for myopic/perfect foresight cb states the carbon budget in GtCO2 (cumulative
   # emissions throughout the transition path in the timeframe determined by the

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -33,7 +33,7 @@ scenario:
   # A for agriculture, forestry and fishing
   # solar+c0.5 reduces the capital cost of solar to 50\% of reference value
   # solar+p3 multiplies the available installable potential by factor 3
-  # seq2 (or e.g. seq0p5) multiplies the potential of CO2 sequestration by a factor 2 (or e.g. 0.5)
+  # seq400 sets the potential of CO2 sequestration to 400 Mt CO2 per year
   # dist{n} includes distribution grids with investment cost of n times cost in data/costs.csv
   # for myopic/perfect foresight cb states the carbon budget in GtCO2 (cumulative
   # emissions throughout the transition path in the timeframe determined by the

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -227,7 +227,8 @@ def add_co2_sequestration_limit(n, sns):
     limit = n.config["sector"].get("co2_sequestration_potential", 200) * 1e6
     for o in opts:
         if not "seq" in o: continue
-        limit = float(o[o.find("seq")+3:])
+        factor = float(o[o.find("seq")+3:])
+        limit *= factor
         break
 
     name = 'co2_sequestration_limit'

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -227,8 +227,7 @@ def add_co2_sequestration_limit(n, sns):
     limit = n.config["sector"].get("co2_sequestration_potential", 200) * 1e6
     for o in opts:
         if not "seq" in o: continue
-        factor = float(o[o.find("seq")+3:])
-        limit *= factor
+        limit = float(o[o.find("seq")+3:]) * 1e6
         break
 
     name = 'co2_sequestration_limit'


### PR DESCRIPTION
The in the `config.yaml` described way to modify the sequestration potential of the CO2 is currently not working correctly. In this PR the description in the `config.yaml` as well as the setting of the constraint in `solve_network.py` are updated.

The CO2 sequestration potential can now be set in the `sector_opts` with e.g. `seq2` to multiply the assumed CO2 storage potential by 2 or `seq0p5` to multiply the assumed CO2 storage potential by 0.5