### PR TITLE
Change default of shipping demand to oil

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -195,14 +195,7 @@ sector:
   agriculture_machinery_electric_efficiency: 0.3 # electricity per use
   shipping_average_efficiency: 0.4 #For conversion of fuel oil to propulsion in 2011
   shipping_hydrogen_liquefaction: false # whether to consider liquefaction costs for shipping H2 demands
-  shipping_hydrogen_share:  # 1 means all hydrogen FC
-    2020: 0
-    2025: 0
-    2030: 0.05
-    2035: 0.15
-    2040: 0.3
-    2045: 0.6
-    2050: 1
+  shipping_hydrogen_share:  0
   time_dep_hp_cop: true #time dependent heat pump coefficient of performance
   heat_pump_sink_T: 55. # Celsius, based on DTU / large area radiators; used in build_cop_profiles.py
    # conservatively high to cover hot water and space heating in poorly-insulated buildings

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -80,6 +80,8 @@ incorporates retrofitting options to hydrogen.
 
 * Updated `data bundle <https://zenodo.org/record/5824485/files/pypsa-eur-sec-data-bundle.tar.gz>`_ that includes the hydrogan salt cavern storage potentials.
 
+* Shipping demand now defaults to (synthetic) oil rather than liquefied hydrogen until 2050.
+
 **Bugfixes**
 
 * The CO2 sequestration limit implemented as GlobalConstraint (introduced in the previous version)


### PR DESCRIPTION
... rather than liquefied hydrogen.

The problem was also that hydrogen demand for shipping was not well spatially resolved, but despite the lack of data drove the hydrogen infrastructure demand.

Oil for shipping (FT or methanol) is not spatially resolved.

Future improvement: endogenous fuel choice between Fischer-Tropsch, fossil oil, methanol, ammonia, liq. hydrogen.