### PR TITLE
automatically retrieve technology-data, no git clone

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,10 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Clone pypsa-eur and technology-data repositories
+      - name: Clone pypsa-eur subworkflow
         run: |
           git clone https://github.com/pypsa/pypsa-eur ../pypsa-eur
-          git clone https://github.com/pypsa/technology-data ../technology-data
           cp ../pypsa-eur/test/config.test1.yaml ../pypsa-eur/config.yaml
       
       - name: Setup secrets

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -3,10 +3,10 @@ version: 0.6.0
 logging_level: INFO
 
 retrieve_sector_databundle: true
+retrieve_cost_data: true
 
 results_dir: results/
 summary_dir: results
-costs_dir: ../technology-data/outputs/
 run: your-run-name  # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "planning_horizons" below
@@ -338,6 +338,7 @@ industry:
 
 costs:
   year: 2030
+  version: v0.4.0
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: 0.07

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,15 +25,6 @@ then download and unpack all the PyPSA-Eur data files by running the following s
     projects/pypsa-eur % snakemake -j 1 retrieve_databundle
 
 
-Clone technology-data repository
-================================
-
-Next install the technology assumptions database `technology-data <https://github.com/PyPSA/technology-data>`_ by creating a parallel directory:
-
-.. code:: bash
-
-    projects % git clone https://github.com/PyPSA/technology-data.git
-
 
 Clone PyPSA-Eur-Sec repository
 ==============================

--- a/test/config.myopic.yaml
+++ b/test/config.myopic.yaml
@@ -3,10 +3,10 @@ version: 0.6.0
 logging_level: INFO
 
 retrieve_sector_databundle: true
+retrieve_cost_data: true
 
 results_dir: results/
 summary_dir: results
-costs_dir: ../technology-data/outputs/
 run: test-myopic  # use this to keep track of runs with different settings
 foresight: myopic # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "planning_horizons" below
@@ -320,6 +320,7 @@ industry:
 
 costs:
   year: 2030
+  version: v0.4.0
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: 0.07

--- a/test/config.overnight.yaml
+++ b/test/config.overnight.yaml
@@ -3,10 +3,10 @@ version: 0.6.0
 logging_level: INFO
 
 retrieve_sector_databundle: true
+retrieve_cost_data: true
 
 results_dir: results/
 summary_dir: results
-costs_dir: ../technology-data/outputs/
 run: test-overnight  # use this to keep track of runs with different settings
 foresight: overnight # options are overnight, myopic, perfect (perfect is not yet implemented)
 # if you use myopic or perfect foresight, set the investment years in "planning_horizons" below
@@ -318,6 +318,7 @@ industry:
 
 costs:
   year: 2030
+  version: v0.4.0
   lifetime: 25 #default lifetime
   # From a Lion Hirth paper, also reflects average of Noothout et al 2016
   discountrate: 0.07


### PR DESCRIPTION
Phase out the need to clone technology-data repository in a parallel directory.

This solution directly retrieves the cost data from Github and is analogous to PyPSA-Eur.