### PR TITLE
add option to use electrolysis waste heat in district heating

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -263,6 +263,7 @@ sector:
   ammonia: false # can be false (no NH3 carrier), true (copperplated NH3), "regional" (regionalised NH3 without network)
   use_fischer_tropsch_waste_heat: true
   use_fuel_cell_waste_heat: true
+  use_electrolysis_waste_heat: false
   electricity_distribution_grid: true
   electricity_distribution_grid_cost_factor: 1.0  #multiplies cost in data/costs.csv
   electricity_grid_connection: true  # only applies to onshore wind and utility PV

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -69,6 +69,8 @@ incorporates retrofitting options to hydrogen.
 
 * Option ``retrieve_sector_databundle`` to automatically retrieve and extract data bundle.
 
+* Add option to use waste heat of electrolysis in district heating networks (``use_electrolysis_waste_heat``).
+
 * Add regionalised hydrogen salt cavern storage potentials from `Technical Potential of Salt Caverns for Hydrogen Storage in Europe <https://doi.org/10.20944/preprints201910.0187.v1>`_.
 
 * Add option to sweep the global CO2 sequestration potentials with keyword ``seq200`` in the ``{sector_opts}`` wildcard (for limit of 200 Mt CO2).

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2470,6 +2470,11 @@ def add_waste_heat(n):
             n.links.loc[urban_central + " Fischer-Tropsch", "bus3"] = urban_central + " urban central heat"
             n.links.loc[urban_central + " Fischer-Tropsch", "efficiency3"] = 0.95 - n.links.loc[urban_central + " Fischer-Tropsch", "efficiency"]
 
+        # TODO integrate useable waste heat efficiency into technology-data from DEA
+        if options.get('use_electrolysis_waste_heat', False):
+            n.links.loc[urban_central + " H2 Electrolysis", "bus2"] = urban_central + " urban central heat"
+            n.links.loc[urban_central + " H2 Electrolysis", "efficiency2"] = 0.84 - n.links.loc[urban_central + " H2 Electrolysis", "efficiency"]
+
         if options['use_fuel_cell_waste_heat']:
             n.links.loc[urban_central + " H2 Fuel Cell", "bus2"] = urban_central + " urban central heat"
             n.links.loc[urban_central + " H2 Fuel Cell", "efficiency2"] = 0.95 - n.links.loc[urban_central + " H2 Fuel Cell", "efficiency"]


### PR DESCRIPTION
We already have options for waste heat recovery in FT and H2-CHP. This PR adds electrolysis to the list.