### PR TITLE
Fixing some warnings in biomass_potentials, gas_input_locations and population_layouts

### DIFF
--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -28,7 +28,8 @@ def build_nuts_population_data(year=2013):
     swiss = [swiss.groupby(swiss.index.str[:i]).sum() for i in range(2, 6)]
 
     # merge Europe + Switzerland
-    pop = pd.DataFrame(pop.append(swiss), columns=["total"])
+    pop = pd.concat([pop, pd.concat(swiss)])
+    pop = pd.DataFrame(pop, columns=["total"])
     
     # add missing manually
     pop["AL"] = 2893

--- a/scripts/build_biomass_potentials.py
+++ b/scripts/build_biomass_potentials.py
@@ -28,8 +28,7 @@ def build_nuts_population_data(year=2013):
     swiss = [swiss.groupby(swiss.index.str[:i]).sum() for i in range(2, 6)]
 
     # merge Europe + Switzerland
-    pop = pd.concat([pop, pd.concat(swiss)])
-    pop = pd.DataFrame(pop, columns=["total"])
+    pop = pd.concat([pop, pd.concat(swiss)]).to_frame("total")
     
     # add missing manually
     pop["AL"] = 2893

--- a/scripts/build_gas_input_locations.py
+++ b/scripts/build_gas_input_locations.py
@@ -31,8 +31,6 @@ def build_gem_lng_data(lng_fn):
               & Country != @remove_country \
               & TerminalName != @remove_terminal \
               & CapacityInMtpa != '--'")
-    
-    df.CapacityInMtpa = df.CapacityInMtpa.astype(float)
 
     geometry = gpd.points_from_xy(df['Longitude'], df['Latitude'])
     return gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     cutout = atlite.Cutout(snakemake.config['atlite']['cutout'])
 
-    grid_cells = cutout.grid_cells()
+    grid_cells = cutout.grid.geometry
 
     # nuts3 has columns country, gdp, pop, geometry
     # population is given in dimensions of 1e3=k


### PR DESCRIPTION
Fixing some warnings in build_biomass_potentials.py, build_gas_input_locations.py, scripts and build_population_layouts.py'

The warning in build_biomass_potentials.py: `FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.`

The warning in build_gas_input_locations: `SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame.`

The info in build_population_layouts: `The order of elements in grid_cells changed. Check the output of your workflow for correctness.`

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes.