### PR TITLE
add highs solver options

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -415,6 +415,17 @@ solving:
     options: gurobi-default
 
   solver_options:
+    highs-default:
+      threads: 4
+      solver: "ipm"
+      run_crossover: "off"
+      small_matrix_value: 1e-6
+      large_matrix_value: 1e9
+      primal_feasibility_tolerance: 1e-5
+      dual_feasibility_tolerance: 1e-5
+      ipm_optimality_tolerance: 1e-4
+      parallel: "on"
+      random_seed: 123
     gurobi-default:
       threads: 4
       method: 2 # barrier


### PR DESCRIPTION
Add highs solver options to the config. They probably can be fine tuned, I have tested them only with a low temporal resolution (120 time steps).

Solver settings for highs can be find [here](https://ergo-code.github.io/HiGHS/options/definitions.html#solver)